### PR TITLE
Add manifest files for deploying the gitea-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [pipelines/README.md](pipelines/README.md)
 ### Gitea in cluster git server for GitOps workflow
 We are relying on the [gitea-operator](https://github.com/rhpds/gitea-operator) to manage the Gitea server installation in the cluster.  This will simplify the setup of Gitea so that we can create a minimal [Gitea](https://github.com/rhpds/gitea-operator#migrating-repositories-for-created-users) CR to configure and install the Gitea server.  The gitea-operator will be installed on the `odh-core` cluster as part of the ACM application rollout.
 
-1. Wait for the gitea-operator installation to complete and the `gitea.pfe-rhdps.com` CRD is available on the `odh-core` cluster
+1. Wait for the gitea-operator installation to complete and the `gitea.pfe-rhpds.com` CRD is available on the `odh-core` cluster
    ```
    $ oc get crd gitea.pfe.rhpds.com
    NAME                  CREATED AT

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ We are relying on the [gitea-operator](https://github.com/rhpds/gitea-operator) 
    kind: Gitea
    metadata:
      name: gitea-ai-edge
-     name: gitea
+     namespace: gitea
    spec:
      # Create the admin user
      giteaAdminUser: admin-edge

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ We are relying on the [gitea-operator](https://github.com/rhpds/gitea-operator) 
 
 1. Create the Gitea CustomResource to deploy the server with an admin user
    ```
+   cat <<EOF | oc apply -f -
    ---
    apiVersion: v1
    kind: Namespace
@@ -97,6 +98,7 @@ We are relying on the [gitea-operator](https://github.com/rhpds/gitea-operator) 
      - repo: https://github.com/opendatahub-io/ai-edge.git
        name: ai-edge-gitops
        private: false
+    EOF
    ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Artifacts in support of ODH Edge use cases that integration with Red Hat Advance
 | Red Hat Advanced Cluster Management  | 2.8     |
 | OpenShift Pipelines                  | 1.11.x  |
 | Quay Registry                        | 2.8     |
+| Gitea                                | 1.20.2  |
 
 ## Proof of Concept Edge use case with ACM
 
@@ -54,6 +55,49 @@ See [pipelines/README.md](pipelines/README.md)
     * `oc -n openshift-monitoring edit configmap cluster-monitoring-config`
     * Set variable `enableUserWorkload` to `true`
   * Edit contents of [thanos-secret](acm/odh-core/acm-observability/secrets/thanos.yaml) file.
+
+### Gitea in cluster git server for GitOps workflow
+We are relying on the [gitea-operator](https://github.com/rhpds/gitea-operator) to manage the Gitea server installation in the cluster.  This will simplify the setup of Gitea so that we can create a minimal [Gitea](https://github.com/rhpds/gitea-operator#migrating-repositories-for-created-users) CR to configure and install the Gitea server.  The gitea-operator will be installed on the `odh-core` cluster as part of the ACM application rollout.
+
+1. Wait for the gitea-operator installation to complete and the `gitea.pfe-rhdps.com` CRD is available on the `odh-core` cluster
+   ```
+   $ oc get crd gitea.pfe.rhpds.com
+   NAME                  CREATED AT
+   gitea.pfe.rhpds.com   2023-08-25T03:00:13Z
+   ```
+
+1. Create the Gitea CustomResource to deploy the server with an admin user
+   ```
+   ---
+   apiVersion: v1
+   kind: Namespace
+   metadata:
+     name: gitea
+   ---
+   apiVersion: pfe.rhpds.com/v1
+   kind: Gitea
+   metadata:
+     name: gitea-ai-edge
+     name: gitea
+   spec:
+     # Create the admin user
+     giteaAdminUser: admin-edge
+     giteaAdminEmail: admin@ai-edge
+     giteaAdminPassword: "opendatahub"
+
+     # Create the gitea users accounts to access the cluster
+     giteaCreateUsers: true
+     giteaGenerateUserFormat: "edge-user-%d"
+     giteaUserNumber: 3
+     giteaUserPassword: "opendatahub"
+
+     # Populate each gitea user org with a clone of the entries in the giteaRepositoriesList
+     giteaMigrateRepositories: true
+     giteaRepositoriesList:
+     - repo: https://github.com/opendatahub-io/ai-edge.git
+       name: ai-edge-gitops
+       private: false
+   ```
 
 ## Contributing
 

--- a/acm/odh-core/olm-operator-subscriptions/gitea/catalogsource.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/gitea/catalogsource.yaml
@@ -1,0 +1,13 @@
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: redhat-rhpds-gitea
+  namespace: gitea-operator
+spec:
+  sourceType: grpc
+  image: quay.io/rhpds/gitea-catalog:latest
+  displayName: Red Hat Demo Platform (Gitea)
+  publisher: Red Hat Demo Platform
+

--- a/acm/odh-core/olm-operator-subscriptions/gitea/kustomization.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/gitea/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+- namespace.yaml
+- catalogsource.yaml
+- operatorgroup.yaml
+- subscription.yaml

--- a/acm/odh-core/olm-operator-subscriptions/gitea/namespace.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/gitea/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitea-operator

--- a/acm/odh-core/olm-operator-subscriptions/gitea/operatorgroup.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/gitea/operatorgroup.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: gitea-operator
+  namespace: gitea-operator
+spec:
+  targetNamespaces: []

--- a/acm/odh-core/olm-operator-subscriptions/gitea/subscription.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/gitea/subscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gitea-operator
+  namespace: gitea-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: gitea-operator
+  source: redhat-rhpds-gitea
+  sourceNamespace: gitea-operator

--- a/acm/odh-core/olm-operator-subscriptions/kustomization.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - operatorgroup.yaml
   - opendatahub-operator.yaml
   - openshift-pipelines.yaml
+  - ../gitea


### PR DESCRIPTION
## Description
Adds support for deploying a Gitea server in the cluster to enable a target for the gitops workflow

Closes #28

## How Has This Been Tested?
Deployed and testing the in demo cluster

## Merge criteria:
Manifest successfully deploys the gitea-operator which also deploy a gitea-server application