### PR TITLE
Add ACM files for registration of odh-core clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The main objective is to showcase that a user can take a trained model, use a pi
    ```
    $  oc apply -k acm/registration
    ```
+
    * Core - Cluster host the ODH Core components that will be used in the MLOps Engineer workflow to train, build and push the model.  This cluster is not required to be co-located with the ACM Hub but we group them together to simplify the use case
    * Near Edge - Cluster(s) that will host the running model at the edge.  This is the target environment after a new model is available for use
 1. Deploy Open Data Hub to the Core cluster and register any configurations to support pushing models to the edge cluster

--- a/acm/registration/odh-core/kustomization.yaml
+++ b/acm/registration/odh-core/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- odh-core/
-- near-edge/
+- odh-core.application.yaml

--- a/acm/registration/odh-core/kustomization.yaml
+++ b/acm/registration/odh-core/kustomization.yaml
@@ -3,3 +3,37 @@ kind: Kustomization
 
 resources:
 - odh-core.application.yaml
+
+replacements:
+- source:
+    group: apps.open-cluster-management.io
+    kind: Channel
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: apps.open-cluster-management.io
+      kind: Subscription
+    fieldPaths:
+      - spec.channel
+
+- source:
+    group: cluster.open-cluster-management.io
+    kind: Placement
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: apps.open-cluster-management.io
+      kind: Subscription
+    fieldPaths:
+      - spec.placement.placementRef.name
+
+- source:
+    group: cluster.open-cluster-management.io
+    kind: ManagedClusterSet
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: apps.open-cluster-management.io
+      kind: Placement
+    fieldPaths:
+      - spec.clusterSets.0

--- a/acm/registration/odh-core/odh-core.application.yaml
+++ b/acm/registration/odh-core/odh-core.application.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: odh-core-acm
+---
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: odh-core
+  namespace: odh-core-acm
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: 
+          - odh-core
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: medium
+  name: channel
+  namespace: odh-core-acm
+spec:
+  type: Git
+  pathname: 'https://github.com/opendatahub-io/ai-edge'
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSet
+metadata:
+  name: odh-core
+spec:
+  clusterSelector:
+    selectorType: ExclusiveClusterSetLabel
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: odh-core
+  namespace: odh-core-acm
+spec:
+  clusterSet: odh-core
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  labels:
+    app: odh-core-acm
+  name: placement
+  namespace: odh-core-acm
+spec:
+  clusterSets:
+    - odh-core
+  predicates:
+    - requiredClusterSelector:
+        labelSelector: {}
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/git-branch: main
+    apps.open-cluster-management.io/git-path: acm/odh-core
+    apps.open-cluster-management.io/reconcile-option: merge
+  labels:
+    app: odh-core
+  name: subscription
+  namespace: odh-core-acm
+spec:
+  channel: github-opendatahub-io-ai-edge-ns/github-opendatahub-io-ai-edge
+  placement:
+    placementRef:
+      kind: Placement
+      name: odh-core-placement


### PR DESCRIPTION
## Description
Add the ACM registration files for `odh-core` cluster to standardize the onboarding of infrastructure using ACM

## How Has This Been Tested?
These files were manually deployed on the ACM hub without any issues and this is a official copy for the ACM repo

## Merge criteria:
No issues visible after review

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
