### PR TITLE
Use ACM app per app to ensure correct NS placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ The main objective is to showcase that a user can take a trained model, use a pi
 1. Configure the default Identity Provider
 1. Install Red Hat Advanced Cluster Management
 1. Register the clusters
-   * Core - Cluster host the ODH Core components that will be used in the MLOps Engineer workflow to train, build and push the model
-   * Near Edge - Cluster that will host the running model at the edge.  This is the target environment after a new model is available for use
+[ACM Application](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/applications/managing-applications) manifests are located in [acm/registration](acm/registration) to register and configure the target environments required for the AI at the Edge use cases.  The files can be applied to the ACM hub cluster manually:
+   ```
+   $  oc apply -k acm/registration
+   ```
+   * Core - Cluster host the ODH Core components that will be used in the MLOps Engineer workflow to train, build and push the model.  This cluster is not required to be co-located with the ACM Hub but we group them together to simplify the use case
+   * Near Edge - Cluster(s) that will host the running model at the edge.  This is the target environment after a new model is available for use
 1. Deploy Open Data Hub to the Core cluster and register any configurations to support pushing models to the edge cluster
    * GitOps repos
    * Image repos

--- a/acm/registration/kustomization.yaml
+++ b/acm/registration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- near-edge

--- a/acm/registration/near-edge/base/kustomization.yaml
+++ b/acm/registration/near-edge/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- near-edge.yaml

--- a/acm/registration/near-edge/base/near-edge.yaml
+++ b/acm/registration/near-edge/base/near-edge.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rhoai-edge-acm
+  name: near-edge-acm-template
 ---
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  name: near-edge
-  namespace: rhoai-edge-acm
+  name: application
+  namespace: near-edge-acm-template
 spec:
   componentKinds:
   - group: apps.open-cluster-management.io
@@ -19,20 +19,15 @@ spec:
       - key: app
         operator: In
         values:
-          - near-edge
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ggithubcom-opendatahub-io-ai-edge-ns
+          - near-edge-acm-template
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
   annotations:
     apps.open-cluster-management.io/reconcile-rate: medium
-  name: ggithubcom-opendatahub-io-ai-edge
-  namespace: ggithubcom-opendatahub-io-ai-edge-ns
+  name: channel
+  namespace: near-edge-acm-template
 spec:
   type: Git
   pathname: 'https://github.com/opendatahub-io/ai-edge'
@@ -41,9 +36,9 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
   labels:
-    app: near-edge
-  name: near-edge-placement
-  namespace: rhoai-edge-acm
+    app: near-edge-acm-template
+  name: placement
+  namespace: near-edge-acm-template
 spec:
   clusterSets:
     - poc-near-edge
@@ -56,15 +51,15 @@ kind: Subscription
 metadata:
   annotations:
     apps.open-cluster-management.io/git-branch: main
-    apps.open-cluster-management.io/git-path: acm/odh-edge/apps
+    apps.open-cluster-management.io/git-path: acm/odh-edge/apps/app
     apps.open-cluster-management.io/reconcile-option: merge
   labels:
-    app: near-edge
-  name: near-edge-subscription
-  namespace: rhoai-edge-acm
+    app: near-edge-acm-template
+  name: subscription
+  namespace: bike-rental-app
 spec:
-  channel: ggithubcom-opendatahub-io-ai-edge-ns/ggithubcom-opendatahub-io-ai-edge
+  channel: channel
   placement:
     placementRef:
       kind: Placement
-      name: near-edge-placement
+      name: placement

--- a/acm/registration/near-edge/kustomization.yaml
+++ b/acm/registration/near-edge/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- overlays/bike-rental-app
+- overlays/tensorflow-housing-app

--- a/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
@@ -30,3 +30,9 @@ patches:
       value: bike-rental-app/bike-rental-app-channel
   target:
     kind: Subscription
+- patch: |-
+    - op: replace
+      path: /spec/pathname
+      value: http://gitea-ai-edge-rhoai-edge-acm.apps.rhoai-edge-acm-poc.rhaiseng.com/edge-user-1/ai-edge-gitops.git
+  target:
+    kind: Channel

--- a/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+namespace: bike-rental-app
+namePrefix: bike-rental-app-
+
+commonAnnotations:
+  apps.open-cluster-management.io/git-path: acm/odh-edge/apps/bike-rental-app
+
+replacements:
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: apps.open-cluster-management.io
+      kind: Subscription
+    fieldPaths:
+      - spec.placement.placementRef.name
+
+# Can't do this as a "replacement", as needs to be of form namespace/name
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: bike-rental-app/bike-rental-app-channel
+  target:
+    kind: Subscription

--- a/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
@@ -30,3 +30,9 @@ patches:
       value: tensorflow-housing-app/tensorflow-housing-app-channel
   target:
     kind: Subscription
+- patch: |-
+    - op: replace
+      path: /spec/pathname
+      value: http://gitea-ai-edge-rhoai-edge-acm.apps.rhoai-edge-acm-poc.rhaiseng.com/edge-user-2/ai-edge-gitops.git
+  target:
+    kind: Channel

--- a/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+namespace: tensorflow-housing-app
+namePrefix: tensorflow-housing-app-
+
+commonAnnotations:
+  apps.open-cluster-management.io/git-path: acm/odh-edge/apps/tensorflow-housing-app
+
+replacements:
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: apps.open-cluster-management.io
+      kind: Subscription
+    fieldPaths:
+      - spec.placement.placementRef.name
+
+# Can't do this as a "replacement", as needs to be of form namespace/name
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: tensorflow-housing-app/tensorflow-housing-app-channel
+  target:
+    kind: Subscription


### PR DESCRIPTION
It seems like all resources get created in a namespace on the target clusters with the same name as the namespace that the subscription on the hub cluster is created in, despite the resources explicitly having a different namespace set.

This change adds new subscriptions such that the two model apps get created in different namespaces on the target clusters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This change is currently rolled out to the ACM cluster, using `oc apply -k acm/registration`, and the synchronization has been successful, and the resources can be seen created on the target clusters.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
