### PR TITLE
use kustomize to set the matchlabel selector on the servicemonitor correctly per app

### DIFF
--- a/acm/odh-edge/apps/bike-rental-app/kustomization.yaml
+++ b/acm/odh-edge/apps/bike-rental-app/kustomization.yaml
@@ -3,5 +3,13 @@ kind: Kustomization
 
 namespace: bike-rental-app
 
+configurations:
+  - servicemonitor-matchlabels.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: bike-rental-app
+
 resources:
 - ../../base

--- a/acm/odh-edge/apps/bike-rental-app/servicemonitor-matchlabels.yaml
+++ b/acm/odh-edge/apps/bike-rental-app/servicemonitor-matchlabels.yaml
@@ -1,0 +1,5 @@
+commonLabels:
+  - path: spec/selector/matchLabels
+    create: true
+    group: monitoring.coreos.com
+    kind: ServiceMonitor

--- a/acm/odh-edge/apps/tensorflow-housing-app/kustomization.yaml
+++ b/acm/odh-edge/apps/tensorflow-housing-app/kustomization.yaml
@@ -3,5 +3,13 @@ kind: Kustomization
 
 namespace: tensorflow-housing-app
 
+configurations:
+  - servicemonitor-matchlabels.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: tensorflow-housing-app
+
 resources:
 - ../../base

--- a/acm/odh-edge/apps/tensorflow-housing-app/servicemonitor-matchlabels.yaml
+++ b/acm/odh-edge/apps/tensorflow-housing-app/servicemonitor-matchlabels.yaml
@@ -1,0 +1,5 @@
+commonLabels:
+  - path: spec/selector/matchLabels
+    create: true
+    group: monitoring.coreos.com
+    kind: ServiceMonitor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The bike-rental app label was hardcoded for the labelSelector. This PR uses kustomize to correctly set the label per app. I had to include a kustomize config file so it knew what to do with the servicemonitor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Run `kustomize build acm/odh-edge/apps/tensorflow-housing-app/`
- Verify the matchLabel selector references tensorflow
- Run `kustomize build acm/odh-edge/apps/bike-rental-app/`
- Verify the matchLabel selector references the bike-rental-app

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
