### PR TITLE
Expose multiple ports in testing pipeline

### DIFF
--- a/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
+++ b/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
@@ -71,25 +71,37 @@ spec:
     taskRef:
       kind: ClusterTask
       name: openshift-client
-  - name: create-default-service
+  - name: create-service
     params:
     - name: SCRIPT
-      value: oc expose deployment  $(params.model-name)-$(params.model-version) --port=8080
-        --target-port=8080 --selector='app=$(params.model-name)-$(params.model-version)'
-        --dry-run=client -o yaml |  oc apply -f -
-    - name: VERSION
-      value: latest
-    runAfter:
-    - deploy-container
-    taskRef:
-      kind: ClusterTask
-      name: openshift-client
-  - name: create-metrics-service
-    params:
-    - name: SCRIPT
-      value: oc expose deployment  $(params.model-name)-$(params.model-version) --name=metrics --port=8082
-        --target-port=8082 --selector='app=$(params.model-name)-$(params.model-version)'
-        --dry-run=client -o yaml |  oc apply -f -
+      value: |
+        cat <<EOF | oc apply -f -
+        apiVersion: v1
+        kind: Service
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: $(params.model-name)-$(params.model-version)
+          name: $(params.model-name)-$(params.model-version)
+        spec:
+          ports:
+          - name: rest
+            port: 8080
+            protocol: TCP
+            targetPort: 8080
+          - name: seldon-metrics
+            port: 8082
+            protocol: TCP
+            targetPort: 8082
+          - name: grpc
+            port: 9090
+            protocol: TCP
+            targetPort: 9090
+          selector:
+            app: $(params.model-name)-$(params.model-version)
+        status:
+          loadBalancer: {}
+        EOF
     - name: VERSION
       value: latest
     runAfter:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Combine multiple `oc expose` statements into one to save time and resources, also expose the gRPC port and label them in the service. (also realized Steven's commit broke the pipeline because of a small detail)

@grdryn Do you want to include this change in your service in `odh-edge`?
@StevenTobin Are you okay with this? This is just the pipeline for testing anyway but it probably doesn't hurt to future-proof in case we add tests for metrics/gRPC.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested it using the commands in the pipelines README, on the `local-cluster/azureml-model-to-edge` namespace.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
