### PR TITLE
Move the ODH Operator subscription to the fast channel for the v2.x release of ODH

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The main objective is to showcase that a user can take a trained model, use a pi
    * Core - Cluster host the ODH Core components that will be used in the MLOps Engineer workflow to train, build and push the model.  This cluster is not required to be co-located with the ACM Hub but we group them together to simplify the use case
    * Near Edge - Cluster(s) that will host the running model at the edge.  This is the target environment after a new model is available for use
 1. Deploy Open Data Hub to the Core cluster and register any configurations to support pushing models to the edge cluster
+   * Open Data Hub - v2.x of the operator will be installed as part of the dependencies for the core cluster.  Manual installation of the [DataScienceCluster](https://github.com/opendatahub-io/opendatahub-operator#example-datasciencecluster) object will be required to deploy the Open Data Hub core stack to support the data science workflow
    * GitOps repos
    * Image repos
 1. Manage the edge cluster environments to support deployment of models and support for monitoring

--- a/acm/odh-core/olm-operator-subscriptions/opendatahub-operator.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/opendatahub-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: opendatahub-operator
   namespace: odh-core-operators
 spec:
-  channel: rolling
+  channel: fast
   name: opendatahub-operator
   source: community-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Description
Updates the ODH Operator subscription to use the `fast` channel for v2.x installations of ODH.  Additionally adds the `DataScienceCluster` installation to deploy ODH in the cluster

Closes #60

## How Has This Been Tested?
Local deployment into my test cluster