### PR TITLE
Make skopeo push to unique tag

### DIFF
--- a/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
+++ b/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
@@ -118,7 +118,7 @@ spec:
     - name: srcImageURL
       value: docker://image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)
     - name: destImageURL
-      value: docker://quay.io/$(params.target-imagerepo)/$(params.model-name):$(params.model-version)
+      value: docker://quay.io/$(params.target-imagerepo)/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)
     - name: srcTLSverify
       value: "true"
     - name: destTLSverify


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Everybody who is using the pipeline code for dev purposes keeps pushing to the `:1` tag on Quay and breaking other people's code. This change pushes the image to a unique tag to avoid that.

Resolves #64

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

![image](https://github.com/opendatahub-io/ai-edge/assets/99439005/fe23a784-9bf4-4b75-afb6-c2153b50d406)

![image](https://github.com/opendatahub-io/ai-edge/assets/99439005/d23309fb-7d6e-4026-9e19-a9a19723707e)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
