### PR TITLE
The Quay repository has to have specific name.

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -58,7 +58,7 @@ oc create -f tekton/azureml-container-pipeline/azureml-container-pipelinerun-ten
 
 ### Quay Repository and Robot Permissions
 
-- Create a repository, add a robot account to push images and set write Permissions for the robot on the repository.
+- In your Quay namespace, create repository `tensorflow-housing`, add a robot account to push images and set write Permissions for the robot on the repository.
 - Download `build-secret.yml`
 - Apply build-secret. E.g.:
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The "a repository" suggests that the repository name does not matter, that it will get configured later.

However, the next steps allow for configuration of the Quay namespace via the `target-imagerepo` parameter, but not the repository name. Incidently, `target-imagerepo` is not a good name for a target namespace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After I renamed the repository to `tensorflow-housing`, the `skopeo-copy` task stopped failing.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
