### PR TITLE
The bucket name does not seem to be needed in aws-storage-config.

### DIFF
--- a/pipelines/tekton/azureml-container-pipeline/aws-env.yaml
+++ b/pipelines/tekton/azureml-container-pipeline/aws-env.yaml
@@ -5,4 +5,4 @@ metadata:
 
 stringData:
   aws-storage-config: |+
-    { "type": "s3", "access_key_id": "$", "secret_access_key": "$", "endpoint_url": "https://example.amazonaws.com/", "bucket": "rhoai-edge-models", "region": "us-west-1" }
+    { "type": "s3", "access_key_id": "$", "secret_access_key": "$", "endpoint_url": "https://example.amazonaws.com/", "region": "us-west-1" }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The bucket name does not seem to be needed in aws-storage-config, it is specified as aws-bucket-name parameter in PipelineRuns.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
