### PR TITLE
Make the git-basic-auth optional, for building from publicly available repo it is not needed.

### DIFF
--- a/pipelines/tekton/azureml-container-pipeline/azureml-container-pipeline.yaml
+++ b/pipelines/tekton/azureml-container-pipeline/azureml-container-pipeline.yaml
@@ -114,3 +114,4 @@ spec:
   - name: buildah-cache
   - name: aws-secret
   - name: git-basic-auth
+    optional: true

--- a/pipelines/tekton/azureml-container-pipeline/azureml-container-pipelinerun-bike-rentals.yaml
+++ b/pipelines/tekton/azureml-container-pipeline/azureml-container-pipelinerun-bike-rentals.yaml
@@ -31,6 +31,3 @@ spec:
   - name: aws-secret
     secret:
         secretName: aws-env
-  - name: git-basic-auth
-    secret:
-      secretName: gitea-edge-user-1

--- a/pipelines/tekton/azureml-container-pipeline/azureml-container-pipelinerun-tensorflow-housing.yaml
+++ b/pipelines/tekton/azureml-container-pipeline/azureml-container-pipelinerun-tensorflow-housing.yaml
@@ -31,6 +31,3 @@ spec:
   - name: aws-secret
     secret:
         secretName: aws-env
-  - name: git-basic-auth
-    secret:
-      secretName: gitea-edge-user-2


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Make the git-basic-auth optional, for building from publicly available repo it is not needed.

Fixes https://github.com/opendatahub-io/ai-edge/issues/85.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually, together with https://github.com/opendatahub-io/ai-edge/pull/108.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
