### PR TITLE
The metrics service is not used in the test-mlflow-image-pipeline in any way.

### DIFF
--- a/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
+++ b/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
@@ -84,19 +84,6 @@ spec:
     taskRef:
       kind: ClusterTask
       name: openshift-client
-  - name: create-metrics-service
-    params:
-    - name: SCRIPT
-      value: oc expose deployment  $(params.model-name)-$(params.model-version) --name=metrics --port=8082
-        --target-port=8082 --selector='app=$(params.model-name)-$(params.model-version)'
-        --dry-run=client -o yaml |  oc apply -f -
-    - name: VERSION
-      value: latest
-    runAfter:
-    - create-default-service
-    taskRef:
-      kind: ClusterTask
-      name: openshift-client
   - name: test-mlflow-rest-svc
     params:
     - name: model-name
@@ -106,7 +93,7 @@ spec:
     - name: test-endpoint
       value: $(params.test-endpoint)
     runAfter:
-    - create-metrics-service
+    - create-default-service
     taskRef:
       kind: Task
       name: test-mlflow-rest-svc


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The metrics service is not used in the test-mlflow-image-pipeline in any way, based on information in https://github.com/opendatahub-io/ai-edge/pull/119#issuecomment-1749253767.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
