### PR TITLE
The gitea-ai-edge-rhoai-edge-acm repo has image digests that do not exist on quay.

### DIFF
--- a/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
@@ -33,6 +33,6 @@ patches:
 - patch: |-
     - op: replace
       path: /spec/pathname
-      value: http://gitea-ai-edge-rhoai-edge-acm.apps.rhoai-edge-acm-poc.rhaiseng.com/edge-user-1/ai-edge-gitops.git
+      value: https://github.com/opendatahub-io/ai-edge
   target:
     kind: Channel

--- a/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
@@ -33,6 +33,6 @@ patches:
 - patch: |-
     - op: replace
       path: /spec/pathname
-      value: http://gitea-ai-edge-rhoai-edge-acm.apps.rhoai-edge-acm-poc.rhaiseng.com/edge-user-2/ai-edge-gitops.git
+      value: https://github.com/opendatahub-io/ai-edge
   target:
     kind: Channel


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The gitea-ai-edge-rhoai-edge-acm repo has image digests that do not exist on quay. So out of box, applications created with
```
oc apply -k acm/registration/
```
crash because they cannot get the container from quay.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
