### PR TITLE
Add support for git credentials for ACM Subscriptions.

### DIFF
--- a/acm/registration/near-edge/base/kustomization.yaml
+++ b/acm/registration/near-edge/base/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 
 resources:
 - near-edge.yaml
+
+configurations:
+- nameReference.yaml

--- a/acm/registration/near-edge/base/nameReference.yaml
+++ b/acm/registration/near-edge/base/nameReference.yaml
@@ -1,0 +1,5 @@
+nameReference:
+  - kind: Secret
+    fieldSpecs:
+      - kind: Channel
+        path: spec/secretRef/name

--- a/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
@@ -7,6 +7,14 @@ resources:
 namespace: bike-rental-app
 namePrefix: bike-rental-app-
 
+# When authenticated Channel is required, set the user and accessToken,
+# and uncomment this section and the replacements section below
+#secretGenerator:
+#- name: git-credentials
+#  literals:
+#  - user=username
+#  - accessToken=access_token
+
 commonAnnotations:
   apps.open-cluster-management.io/git-path: acm/odh-edge/apps/bike-rental-app
 
@@ -21,6 +29,18 @@ replacements:
       kind: Subscription
     fieldPaths:
       - spec.placement.placementRef.name
+#- source:
+#    kind: Secret
+#    name: git-credentials
+#    fieldPath: metadata.name
+#  targets:
+#  - select:
+#      group: apps.open-cluster-management.io
+#      kind: Channel
+#    fieldPaths:
+#      - spec.secretRef.name
+#    options:
+#      create: true
 
 # Can't do this as a "replacement", as needs to be of form namespace/name
 patches:

--- a/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
@@ -4,6 +4,14 @@ kind: Kustomization
 resources:
 - ../../base
 
+# When authenticated Channel is required, set the user and accessToken,
+# and uncomment this section and the replacements section below
+#secretGenerator:
+#- name: git-credentials
+#  literals:
+#  - user=username
+#  - accessToken=access_token
+
 namespace: tensorflow-housing-app
 namePrefix: tensorflow-housing-app-
 
@@ -21,6 +29,18 @@ replacements:
       kind: Subscription
     fieldPaths:
       - spec.placement.placementRef.name
+#- source:
+#    kind: Secret
+#    name: git-credentials
+#    fieldPath: metadata.name
+#  targets:
+#  - select:
+#      group: apps.open-cluster-management.io
+#      kind: Channel
+#    fieldPaths:
+#      - spec.secretRef.name
+#    options:
+#      create: true
 
 # Can't do this as a "replacement", as needs to be of form namespace/name
 patches:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for git credentials for ACM Subscriptions.

Since the GitOps pipeline can file pull requests with container image changes in authenticated git repositories, ACM should be able to deploy applications from those repositories as well.

I tested that a different access token can be used (only for reading).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
