### PR TITLE
Move gitea manifest out of the odh-core ACM Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ For the purpose of a "near edge" Proof of Concept, the edge environment is repre
 managed from a core OpenShift cluster using Red Hat Advanced Cluster Management (ACM),
 based on the Open Cluster Management project.
 
-| Components                                          | Version        |
-|-----------------------------------------------------|----------------|
-| OpenShift clusters (at least two) with admin access | 4.12 or higher |
-| GitHub account or Gitea installation                | [github.com](https://github.com/) |
-| AWS account with access to S3                       | [s3.console.aws.amazon.com](https://s3.console.aws.amazon.com/) |
-| Red Hat OpenShift Pipelines                         | 1.11 or higher |
-| Quay Registry account                               | [quay.io](https://quay.io/) |
-| Advanced Cluster Management for Kubernetes          | 2.8            |
-| Open Data Hub (optional)                            | 1.x or 2.x     |
+| Components                                              | Version        |
+|---------------------------------------------------------|----------------|
+| OpenShift clusters (at least two) with admin access     | 4.12 or higher |
+| GitHub account or [Gitea installation](gitea/README.md) | [github.com](https://github.com/) |
+| AWS account with access to S3                           | [s3.console.aws.amazon.com](https://s3.console.aws.amazon.com/) |
+| Red Hat OpenShift Pipelines                             | 1.11 or higher |
+| Quay Registry account                                   | [quay.io](https://quay.io/) |
+| Advanced Cluster Management for Kubernetes              | 2.8            |
+| Open Data Hub (optional)                                | 1.x or 2.x     |
 
 ## Proof of Concept Edge use case with ACM
 
@@ -142,53 +142,6 @@ Everything should be shown green. If it is not, click the icon of the faulty obj
     * `oc -n openshift-monitoring edit configmap cluster-monitoring-config`
     * Set variable `enableUserWorkload` to `true`
   * Edit contents of [thanos-secret](acm/odh-core/acm-observability/secrets/thanos.yaml) file.
-
-### Gitea in cluster git server for GitOps workflow
-
-You can use your own git server instead of GitHub.
-For example, the [gitea-operator](https://github.com/rhpds/gitea-operator) can be used to manage the Gitea server installation in the cluster.  It will simplify the setup so that you can create a minimal [Gitea](https://github.com/rhpds/gitea-operator#migrating-repositories-for-created-users) CR to configure and install the Gitea server.
-
-1. Wait for the gitea-operator installation to complete and the `gitea.pfe-rhpds.com` CRD is available on the `odh-core` cluster
-   ```
-   $ oc get crd gitea.pfe.rhpds.com
-   NAME                  CREATED AT
-   gitea.pfe.rhpds.com   2023-08-25T03:00:13Z
-   ```
-
-1. Create the Gitea CustomResource to deploy the server with an admin user
-   ```
-   cat <<EOF | oc apply -f -
-   ---
-   apiVersion: v1
-   kind: Namespace
-   metadata:
-     name: gitea
-   ---
-   apiVersion: pfe.rhpds.com/v1
-   kind: Gitea
-   metadata:
-     name: gitea-ai-edge
-     namespace: gitea
-   spec:
-     # Create the admin user
-     giteaAdminUser: admin-edge
-     giteaAdminEmail: admin@ai-edge
-     giteaAdminPassword: "opendatahub"
-
-     # Create the gitea users accounts to access the cluster
-     giteaCreateUsers: true
-     giteaGenerateUserFormat: "edge-user-%d"
-     giteaUserNumber: 3
-     giteaUserPassword: "opendatahub"
-
-     # Populate each gitea user org with a clone of the entries in the giteaRepositoriesList
-     giteaMigrateRepositories: true
-     giteaRepositoriesList:
-     - repo: https://github.com/opendatahub-io/ai-edge.git
-       name: ai-edge-gitops
-       private: false
-    EOF
-   ```
 
 ## Contributing
 

--- a/acm/odh-core/olm-operator-subscriptions/kustomization.yaml
+++ b/acm/odh-core/olm-operator-subscriptions/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - operatorgroup.yaml
   - opendatahub-operator.yaml
   - openshift-pipelines.yaml
-  - ../gitea

--- a/gitea/README.md
+++ b/gitea/README.md
@@ -1,0 +1,33 @@
+### Gitea in cluster git server for GitOps workflow
+You can deploy a [Gitea](https://about.gitea.com/) server in your cluster instead of GitHub to provide a self contained GitOps workflow environment for your specific use case.
+
+The [gitea-operator](https://github.com/rhpds/gitea-operator) can be used to manage the Gitea server installation in the cluster.  It will simplify the setup so that you can create a minimal [Gitea](https://github.com/rhpds/gitea-operator#migrating-repositories-for-created-users) CR to configure and install the Gitea server.
+
+1. Install the [OpenShift Lifecycle Manager](https://docs.openshift.com/container-platform/4.13/operators/understanding/olm/olm-understanding-olm.html) `CatalogSource` and `Subscription` to deploy the `gitea-operator` in the cluster
+   ```bash
+   oc apply -k gitea/operator
+   ```
+
+1. Wait for the gitea-operator installation to complete and the `gitea.pfe-rhpds.com` CRD is available on the `odh-core` cluster
+   ```bash
+   $ oc get crd gitea.pfe.rhpds.com
+   NAME                  CREATED AT
+   gitea.pfe.rhpds.com   2023-08-25T03:00:13Z
+   ```
+
+1. Create the Gitea CustomResource to deploy the server with an admin user
+   ```bash
+   oc apply -k gitea/server
+   ```
+
+1. Once complete, there will be a gitea application deployed in the `gitea` namespace on the cluster.
+   You can login to the gitea server on the route in the `gitea` namespace using the credentials specifed
+   in the [gitea](server/gitea.yaml)
+   ```bash
+   GITEA_SERVER_URL="http://$(oc get route -n gitea  gitea-ai-edge -o jsonpath='{.spec.host}')"
+   ```
+
+   Open a browser to `${GITEA_SERVER_URL}` OR `git clone` the repo locally to customize the manifests for your use case
+   ```bash
+   git clone ${GITEA_SERVER_URL}/edge-user-1/ai-edge-gitops
+   ```

--- a/gitea/operator/catalogsource.yaml
+++ b/gitea/operator/catalogsource.yaml
@@ -1,10 +1,7 @@
-
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: redhat-rhpds-gitea
-  namespace: gitea-operator
 spec:
   sourceType: grpc
   image: quay.io/rhpds/gitea-catalog:latest

--- a/gitea/operator/kustomization.yaml
+++ b/gitea/operator/kustomization.yaml
@@ -1,4 +1,8 @@
----
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: gitea
+
 resources:
 - namespace.yaml
 - catalogsource.yaml

--- a/gitea/operator/namespace.yaml
+++ b/gitea/operator/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: gitea-operator
+  name: gitea

--- a/gitea/operator/operatorgroup.yaml
+++ b/gitea/operator/operatorgroup.yaml
@@ -3,6 +3,5 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: gitea-operator
-  namespace: gitea-operator
 spec:
   targetNamespaces: []

--- a/gitea/operator/subscription.yaml
+++ b/gitea/operator/subscription.yaml
@@ -3,7 +3,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: gitea-operator
-  namespace: gitea-operator
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/gitea/server/gitea.yaml
+++ b/gitea/server/gitea.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitea
+---
+apiVersion: pfe.rhpds.com/v1
+kind: Gitea
+metadata:
+  name: gitea-ai-edge
+  namespace: gitea
+spec:
+  # Create the admin user
+  giteaAdminUser: admin-edge
+  giteaAdminEmail: admin@ai-edge
+  giteaAdminPassword: "opendatahub"
+
+  # Create the gitea users accounts to access the cluster
+  giteaCreateUsers: true
+  giteaGenerateUserFormat: "edge-user-%d"
+  # Change this to the number of users you want to pre-populate on the Gitea server
+  giteaUserNumber: 3
+  giteaUserPassword: "opendatahub"
+
+  # Populate each gitea user org with a clone of the entries in the giteaRepositoriesList
+  giteaMigrateRepositories: true
+  giteaRepositoriesList:
+  - repo: https://github.com/opendatahub-io/ai-edge.git
+    name: ai-edge-gitops
+    private: false

--- a/gitea/server/kustomization.yaml
+++ b/gitea/server/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: gitea
+
+resources:
+- gitea.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move the gitea info and manifests to a gitea repo as an optional component that users can deploy manually for there use case

Closes #129 
Closes #116

## How Has This Been Tested?
Manually deployment to ensure the gitea kustomize manifests parse and apply successfully

## Merge criteria:
Info is  accurate and easy to understand

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
