### PR TITLE
Add OWNERS file to the repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- adelton
+- devguyio
+- grdryn
+- lavlas
+- winklerm
+
+reviewers:
+- biswassri
+- jackdelahunt
+- MarianMacik
+- piotrpdev
+- Sara4994
+- steventobin


### PR DESCRIPTION
## Description
Add an OWNERS file that is required for the onboarding to [Prow](https://github.com/openshift/release) and enabling the [tide](https://docs.prow.k8s.io/docs/components/core/tide/pr-authors/) plugin

## How Has This Been Tested?
N/A

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
