### PR TITLE
Tolerate unreachable clusters in Placement

### DIFF
--- a/acm/registration/near-edge/base/near-edge.yaml
+++ b/acm/registration/near-edge/base/near-edge.yaml
@@ -40,6 +40,11 @@ spec:
   predicates:
     - requiredClusterSelector:
         labelSelector: {}
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription


### PR DESCRIPTION
> In some unstable network scenarios, the managed clusters might be temporarily placed in unavailable or unreachable state.

That sounds very relevant to our use cases.

See the following section of the ACM docs for more info:
https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/applications/managing-applications#tolerations-config