### PR TITLE
Add a dummy Makefile test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install/observability-core install/observability-edge test-acm-%-generate
+.PHONY: install install/observability-core install/observability-edge test-acm-%-generate test
 
 install: install/observability-core install/observability-edge
 
@@ -27,3 +27,7 @@ ifndef TEST_NAMESPACE
 	$(error TEST_NAMESPACE is undefined)
 endif
 	kustomize build test/acm/$(subst -generate,,$(subst test-acm-,,$@))/ | sed -e "s|https://github.com/opendatahub-io/ai-edge|$(GIT_REPO_URL)|g" -e "s|my-git-branch|$(GIT_BRANCH)|g" -e "s|my-test-namespace|$(TEST_NAMESPACE)|g"
+
+# Dummy target to allow onboarding to openshift-ci
+test:
+	echo "The tests will be run here"


### PR DESCRIPTION
Added a dummy Makefile test target to allow onboarding to openshift-ci. Related to https://github.com/opendatahub-io/ai-edge/issues/166.

## How Has This Been Tested?
Run `make test`, the expected message is printed out.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
