### PR TITLE
RHOAIENG-203: Use ArgoCD pull controller integration for GitOps

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,42 +58,29 @@ We use a mix of AWS and GCP to host these clusters for diversity. Typically you 
 
 * Create a new testing branch on your fork of the `opendatahub-io/ai-edge` repo, preferably named `<your-kerberos-name>-acm-dev`.
 * Ensure that you change `namespace` in either `test/gitops/bike-rental-app/kustomization.yaml` or `test/gitops/tensorflow-housing-app/kustomization.yaml`, or both, as appropriate.
-* Substitute the values of the `GIT_REPO_URL`, `GIT_BRANCH`, and `TEST_NAMESPACE` variables in this `make` command appropriately:
+* Substitute the values of the `GIT_REPO_URL`, `GIT_BRANCH`, `CUSTOM_PREFIX`, and `CUSTOM_APP_NAMESPACE` variables in this `make` command appropriately:
 NOTE: Escape the `:` in the `https://` protocol part of the `GIT_REPO_URL` value
 ```bash
 make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" \
-     -e GIT_BRANCH=my-git-branch \
-     -e TEST_NAMESPACE=my-test-namespace \
+     GIT_BRANCH=my-git-branch \
+     CUSTOM_PREFIX=custom-prefix- \
+     CUSTOM_APP_NAMESPACE=my-test-namespace \
      test-acm-bike-rental-app-generate # or test-acm-tensorflow-housing-generate
 ```
 * You can also do a dry-run apply of these manifests, by piping the output to `oc apply -f - --dry-run=client`, like this:
 
 ```bash
 make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" \
-     -e GIT_BRANCH=my-git-branch \
-     -e TEST_NAMESPACE=my-test-namespace \
+     GIT_BRANCH=my-git-branch \
+     CUSTOM_PREFIX=custom-prefix- \
+     CUSTOM_APP_NAMESPACE=my-test-namespace \
      test-acm-bike-rental-app-generate # or test-acm-tensorflow-housing-generate | oc apply -f - --dry-run=client
 ```
 * If everything looks correct, run the make target again and apply the manifests to the hub cluster without the dry-run option
 ```bash
 make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" \
-     -e GIT_BRANCH=my-git-branch \
-     -e TEST_NAMESPACE=my-test-namespace \
+     GIT_BRANCH=my-git-branch \
+     CUSTOM_PREFIX=custom-prefix- \
+     CUSTOM_APP_NAMESPACE=my-test-namespace \
      test-acm-bike-rental-app-generate  | oc apply -f -
 ```
-* Add your dev namespace to the near-edge Cluster Set's `Namespace Bindings`.
-  * In the OpenShift Console, navigate to `All Clusters (dropdown in top left) -> Infrastructure -> Clusters -> Cluster sets -> <cluster-set-name> -> Namespace Bindings`.
-
-      OR
-
-  * ```bash
-      cat << EOF | oc apply -f -
-      apiVersion: cluster.open-cluster-management.io/v1beta2
-      kind: ManagedClusterSetBinding
-      metadata:
-         name: ___CLUSTER_SET_NAME___
-         namespace: ___DEV_NAMESPACE___
-      spec:
-         clusterSet: ___CLUSTER_SET_NAME___
-      EOF
-      ```

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ install/observability-edge: acm/odh-edge/acm-observability/kustomization.yaml
 
 # Generate app manifests using ACM GitOps flow, from custom GitHub org/branch, to custom namespace
 # Example invocations:
-# make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" -e GIT_BRANCH=my-git-branch -e TEST_NAMESPACE=my-test-namespace test-acm-bike-rental-app-generate
-# make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" -e GIT_BRANCH=my-git-branch -e TEST_NAMESPACE=my-test-namespace test-acm-tensorflow-housing-app-generate
+# make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" GIT_BRANCH=my-git-branch CUSTOM_PREFIX=custom- CUSTOM_APP_NAMESPACE=custom-bike-rental-app test-acm-bike-rental-app-generate
+# make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" GIT_BRANCH=my-git-branch CUSTOM_PREFIX=custom- CUSTOM_APP_NAMESPACE=custom-tensorflow-housing test-acm-tensorflow-housing-app-generate
 test-acm-%-generate: test/acm/%/kustomization.yaml
 ifndef GIT_REPO_URL
 	$(error GIT_REPO_URL is undefined)
@@ -23,10 +23,13 @@ endif
 ifndef GIT_BRANCH
 	$(error GIT_BRANCH is undefined)
 endif
-ifndef TEST_NAMESPACE
-	$(error TEST_NAMESPACE is undefined)
+ifndef CUSTOM_PREFIX
+	$(error CUSTOM_PREFIX is undefined)
 endif
-	kustomize build test/acm/$(subst -generate,,$(subst test-acm-,,$@))/ | sed -e "s|https://github.com/opendatahub-io/ai-edge|$(GIT_REPO_URL)|g" -e "s|my-git-branch|$(GIT_BRANCH)|g" -e "s|my-test-namespace|$(TEST_NAMESPACE)|g"
+ifndef CUSTOM_APP_NAMESPACE
+	$(error CUSTOM_APP_NAMESPACE is undefined)
+endif
+	kustomize build test/acm/$(subst -generate,,$(subst test-acm-,,$@))/ | sed -e "s|https://github.com/opendatahub-io/ai-edge|$(GIT_REPO_URL)|g" -e "s|my-git-branch|$(GIT_BRANCH)|g" -e "s|custom-prefix-|$(CUSTOM_PREFIX)|g" -e "s|custom-app-namespace|$(CUSTOM_APP_NAMESPACE)|g"
 
 GO=go
 GOFLAGS=""

--- a/acm/registration/near-edge/base/near-edge.yaml
+++ b/acm/registration/near-edge/base/near-edge.yaml
@@ -1,39 +1,36 @@
 ---
-apiVersion: app.k8s.io/v1beta1
-kind: Application
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
 metadata:
-  name: application
-  namespace: near-edge-acm-template
+  name: namespace-policy
+  namespace: openshift-gitops
 spec:
-  componentKinds:
-  - group: apps.open-cluster-management.io
-    kind: Subscription
-  descriptor: {}
-  selector:
-    matchExpressions:
-      - key: app
-        operator: In
-        values:
-          - near-edge-acm-template
----
-apiVersion: apps.open-cluster-management.io/v1
-kind: Channel
-metadata:
-  annotations:
-    apps.open-cluster-management.io/reconcile-rate: medium
-  name: channel
-  namespace: near-edge-acm-template
-spec:
-  type: Git
-  pathname: 'https://github.com/opendatahub-io/ai-edge'
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: ns-has-argo-label
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  labels:
+                    argocd.argoproj.io/managed-by: openshift-gitops
+                  name: near-edge-acm-template
+          pruneObjectBehavior: DeleteIfCreated
+          severity: low
+          remediationAction: enforce
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-  labels:
-    app: near-edge-acm-template
   name: placement
-  namespace: near-edge-acm-template
+  namespace: openshift-gitops
 spec:
   clusterSets:
     - poc-near-edge
@@ -46,20 +43,53 @@ spec:
     - key: cluster.open-cluster-management.io/unavailable
       operator: Exists
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: Subscription
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
 metadata:
-  annotations:
-    apps.open-cluster-management.io/git-branch: main
-    apps.open-cluster-management.io/git-path: acm/odh-edge/apps/app
-    apps.open-cluster-management.io/reconcile-option: merge
-  labels:
-    app: near-edge-acm-template
-  name: subscription
-  namespace: bike-rental-app
+  name: placement-binding
+  namespace: openshift-gitops
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: near-edge-clusters
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: ensure-namespace-exists
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: appset
+  namespace: openshift-gitops
 spec:
-  channel: channel
-  placement:
-    placementRef:
-      kind: Placement
-      name: placement
+  generators:
+    - clusterDecisionResource:
+        configMapRef: ocm-placement-generator
+        labelSelector:
+          matchLabels:
+            cluster.open-cluster-management.io/placement: placement
+        requeueAfterSeconds: 30
+  template:
+    metadata:
+      name: '{{name}}-application'
+      labels:
+        apps.open-cluster-management.io/pull-to-ocm-managed-cluster: 'true'
+      annotations:
+        argocd.argoproj.io/skip-reconcile: 'true'
+        apps.open-cluster-management.io/ocm-managed-cluster: '{{name}}'
+        apps.open-cluster-management.io/ocm-managed-cluster-app-namespace: near-edge-acm-template
+    spec:
+      project: default
+      source:
+        repoURL: 'https://github.com/opendatahub-io/ai-edge.git'
+        targetRevision: main
+        path: acm/odh-edge/apps/app
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: near-edge-acm-template
+      syncPolicy:
+        automated:
+          prune: true
+        syncOptions:
+          - CreateNamespace=true

--- a/acm/registration/near-edge/kustomization.yaml
+++ b/acm/registration/near-edge/kustomization.yaml
@@ -2,5 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- openshift-gitops-managedclustersetbinding.yaml
+- openshift-gitops-placement.yaml
+- openshift-gitops-gitopscluster.yaml
 - overlays/bike-rental-app
 - overlays/tensorflow-housing-app

--- a/acm/registration/near-edge/openshift-gitops-gitopscluster.yaml
+++ b/acm/registration/near-edge/openshift-gitops-gitopscluster.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps.open-cluster-management.io/v1beta1
+kind: GitOpsCluster
+metadata:
+  name: near-edge-clusters
+  namespace: openshift-gitops
+spec:
+  argoServer:
+    cluster: notused
+    argoNamespace: openshift-gitops
+  placementRef:
+    kind: Placement
+    apiVersion: cluster.open-cluster-management.io/v1beta1
+    name: near-edge-clusters

--- a/acm/registration/near-edge/openshift-gitops-managedclustersetbinding.yaml
+++ b/acm/registration/near-edge/openshift-gitops-managedclustersetbinding.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: poc-near-edge
+  namespace: openshift-gitops
+spec:
+  clusterSet: poc-near-edge

--- a/acm/registration/near-edge/openshift-gitops-placement.yaml
+++ b/acm/registration/near-edge/openshift-gitops-placement.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: near-edge-clusters
+  namespace: openshift-gitops
+spec:
+  clusterSets:
+    - poc-near-edge
+  predicates:
+    - requiredClusterSelector:
+        labelSelector: {}
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
@@ -4,19 +4,34 @@ kind: Kustomization
 resources:
 - ../../base
 
-namespace: bike-rental-app
 namePrefix: bike-rental-app-
 
-# When authenticated Channel is required, set the user and accessToken,
-# and uncomment this section and the replacements section below
-#secretGenerator:
-#- name: git-credentials
-#  literals:
-#  - user=username
-#  - accessToken=access_token
-
-commonAnnotations:
-  apps.open-cluster-management.io/git-path: acm/odh-edge/apps/bike-rental-app
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/template/metadata/name
+      value: '{{name}}-bike-rental-app'
+    - op: replace
+      path: /spec/template/spec/source/path
+      value: acm/odh-edge/apps/bike-rental-app
+    - op: replace
+      path: /spec/template/spec/destination/namespace
+      value: bike-rental-app
+    - op: replace
+      path: /spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace
+      value: openshift-gitops
+  target:
+    group: argoproj.io
+    version: v1alpha1
+    kind: ApplicationSet
+- patch: |-
+    - op: replace
+      path: /spec/policy-templates/0/objectDefinition/metadata/name
+      value: bike-rental-app-ns-has-argo-label
+  target:
+    group: policy.open-cluster-management.io
+    version: v1
+    kind: Policy
 
 replacements:
 - source:
@@ -25,34 +40,37 @@ replacements:
     fieldPath: metadata.name
   targets:
   - select:
-      group: apps.open-cluster-management.io
-      kind: Subscription
+      group: argoproj.io
+      kind: ApplicationSet
     fieldPaths:
-      - spec.placement.placementRef.name
-#- source:
-#    kind: Secret
-#    name: git-credentials
-#    fieldPath: metadata.name
-#  targets:
-#  - select:
-#      group: apps.open-cluster-management.io
-#      kind: Channel
-#    fieldPaths:
-#      - spec.secretRef.name
-#    options:
-#      create: true
-
-# Can't do this as a "replacement", as needs to be of form namespace/name
-patches:
-- patch: |-
-    - op: replace
-      path: /spec/channel
-      value: bike-rental-app/bike-rental-app-channel
-  target:
-    kind: Subscription
-- patch: |-
-    - op: replace
-      path: /spec/pathname
-      value: https://github.com/opendatahub-io/ai-edge
-  target:
-    kind: Channel
+      - spec.generators.0.clusterDecisionResource.labelSelector.matchLabels.cluster\.open-cluster-management\.io/placement
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - placementRef.name
+- source:
+    kind: Policy
+    group: policy.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - subjects.0.name
+- source:
+    group: argoproj.io
+    kind: ApplicationSet
+    fieldPath: spec.template.spec.destination.namespace
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: Policy
+    fieldPaths:
+    - spec.policy-templates.0.objectDefinition.spec.object-templates.0.objectDefinition.metadata.name

--- a/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
@@ -4,19 +4,34 @@ kind: Kustomization
 resources:
 - ../../base
 
-# When authenticated Channel is required, set the user and accessToken,
-# and uncomment this section and the replacements section below
-#secretGenerator:
-#- name: git-credentials
-#  literals:
-#  - user=username
-#  - accessToken=access_token
-
-namespace: tensorflow-housing-app
 namePrefix: tensorflow-housing-app-
 
-commonAnnotations:
-  apps.open-cluster-management.io/git-path: acm/odh-edge/apps/tensorflow-housing-app
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/template/metadata/name
+      value: '{{name}}-tensorflow-housing-app'
+    - op: replace
+      path: /spec/template/spec/source/path
+      value: acm/odh-edge/apps/tensorflow-housing-app
+    - op: replace
+      path: /spec/template/spec/destination/namespace
+      value: tensorflow-housing-app
+    - op: replace
+      path: /spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace
+      value: openshift-gitops
+  target:
+    group: argoproj.io
+    version: v1alpha1
+    kind: ApplicationSet
+- patch: |-
+    - op: replace
+      path: /spec/policy-templates/0/objectDefinition/metadata/name
+      value: tensorflow-housing-app-ns-has-argo-label
+  target:
+    group: policy.open-cluster-management.io
+    version: v1
+    kind: Policy
 
 replacements:
 - source:
@@ -25,34 +40,37 @@ replacements:
     fieldPath: metadata.name
   targets:
   - select:
-      group: apps.open-cluster-management.io
-      kind: Subscription
+      group: argoproj.io
+      kind: ApplicationSet
     fieldPaths:
-      - spec.placement.placementRef.name
-#- source:
-#    kind: Secret
-#    name: git-credentials
-#    fieldPath: metadata.name
-#  targets:
-#  - select:
-#      group: apps.open-cluster-management.io
-#      kind: Channel
-#    fieldPaths:
-#      - spec.secretRef.name
-#    options:
-#      create: true
-
-# Can't do this as a "replacement", as needs to be of form namespace/name
-patches:
-- patch: |-
-    - op: replace
-      path: /spec/channel
-      value: tensorflow-housing-app/tensorflow-housing-app-channel
-  target:
-    kind: Subscription
-- patch: |-
-    - op: replace
-      path: /spec/pathname
-      value: https://github.com/opendatahub-io/ai-edge
-  target:
-    kind: Channel
+      - spec.generators.0.clusterDecisionResource.labelSelector.matchLabels.cluster\.open-cluster-management\.io/placement
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - placementRef.name
+- source:
+    kind: Policy
+    group: policy.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - subjects.0.name
+- source:
+    group: argoproj.io
+    kind: ApplicationSet
+    fieldPath: spec.template.spec.destination.namespace
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: Policy
+    fieldPaths:
+    - spec.policy-templates.0.objectDefinition.spec.object-templates.0.objectDefinition.metadata.name

--- a/acm/registration/near-edge/test/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/test/bike-rental-app/kustomization.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../overlays/bike-rental-app/
+
+patches:
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: bike-rental-app-appset
+    - op: test
+      path: /spec/template/metadata/name
+      value: '{{name}}-bike-rental-app'
+    - op: test
+      path: /spec/template/spec/source/path
+      value: acm/odh-edge/apps/bike-rental-app
+    - op: test
+      path: /spec/template/spec/destination/namespace
+      value: bike-rental-app
+    - op: test
+      path: /spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace
+      value: openshift-gitops
+    - op: test
+      path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+      value: bike-rental-app-placement
+  target:
+    group: argoproj.io
+    kind: ApplicationSet
+
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: bike-rental-app-namespace-policy
+    - op: test
+      path: /spec/policy-templates/0/objectDefinition/metadata/name
+      value: bike-rental-app-ns-has-argo-label
+    - op: test
+      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
+      value: bike-rental-app
+  target:
+    group: policy.open-cluster-management.io
+    kind: Policy
+
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: bike-rental-app-placement-binding
+    - op: test
+      path: /placementRef/name
+      value: bike-rental-app-placement
+    - op: test
+      path: /subjects/0/name
+      value: bike-rental-app-namespace-policy
+  target:
+    group: policy.open-cluster-management.io
+    kind: PlacementBinding
+
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: bike-rental-app-placement
+  target:
+    group: cluster.open-cluster-management.io
+    kind: Placement

--- a/acm/registration/near-edge/test/kustomization.yaml
+++ b/acm/registration/near-edge/test/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- bike-rental-app
+- tensorflow-housing-app

--- a/acm/registration/near-edge/test/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/test/tensorflow-housing-app/kustomization.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../overlays/tensorflow-housing-app/
+
+patches:
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: tensorflow-housing-app-appset
+    - op: test
+      path: /spec/template/metadata/name
+      value: '{{name}}-tensorflow-housing-app'
+    - op: test
+      path: /spec/template/spec/source/path
+      value: acm/odh-edge/apps/tensorflow-housing-app
+    - op: test
+      path: /spec/template/spec/destination/namespace
+      value: tensorflow-housing-app
+    - op: test
+      path: /spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace
+      value: openshift-gitops
+    - op: test
+      path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+      value: tensorflow-housing-app-placement
+  target:
+    group: argoproj.io
+    kind: ApplicationSet
+
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: tensorflow-housing-app-namespace-policy
+    - op: test
+      path: /spec/policy-templates/0/objectDefinition/metadata/name
+      value: tensorflow-housing-app-ns-has-argo-label
+    - op: test
+      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
+      value: tensorflow-housing-app
+  target:
+    group: policy.open-cluster-management.io
+    kind: Policy
+
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: tensorflow-housing-app-placement-binding
+    - op: test
+      path: /placementRef/name
+      value: tensorflow-housing-app-placement
+    - op: test
+      path: /subjects/0/name
+      value: tensorflow-housing-app-namespace-policy
+  target:
+    group: policy.open-cluster-management.io
+    kind: PlacementBinding
+
+- patch: |-
+    - op: test
+      path: /metadata/name
+      value: tensorflow-housing-app-placement
+  target:
+    group: cluster.open-cluster-management.io
+    kind: Placement

--- a/test/acm/bike-rental-app/kustomization.yaml
+++ b/test/acm/bike-rental-app/kustomization.yaml
@@ -4,22 +4,62 @@ kind: Kustomization
 resources:
 - ../../../acm/registration/near-edge/overlays/bike-rental-app/
 
-namespace: my-test-namespace
+namePrefix: custom-prefix-
 
 patches:
 - patch: |-
     - op: replace
-      path: /spec/channel
-      value: my-test-namespace/bike-rental-app-channel
+      path: /spec/template/metadata/name
+      value: '{{name}}-bike-rental-app'
+    - op: replace
+      path: /spec/template/spec/source/targetRevision
+      value: my-git-branch
+    - op: replace
+      path: /spec/template/spec/source/path
+      value: test/gitops/bike-rental-app/
+    - op: replace
+      path: /spec/template/spec/destination/namespace
+      value: custom-app-namespace
   target:
-    kind: Subscription
+    kind: ApplicationSet
 - patch: |-
     - op: replace
-      path: /spec/pathname
-      value: https://github.com/opendatahub-io/ai-edge
+      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
+      value: custom-app-namespace
+    - op: replace
+      path: /spec/policy-templates/0/objectDefinition/metadata/name
+      value: custom-app-namespace-has-argo-label
   target:
-    kind: Channel
+    kind: Policy
 
-commonAnnotations:
-  apps.open-cluster-management.io/git-branch: my-git-branch
-  apps.open-cluster-management.io/git-path: test/gitops/bike-rental-app/
+replacements:
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: argoproj.io
+      kind: ApplicationSet
+    fieldPaths:
+      - spec.generators.0.clusterDecisionResource.labelSelector.matchLabels.cluster\.open-cluster-management\.io/placement
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - placementRef.name
+- source:
+    kind: Policy
+    group: policy.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - subjects.0.name

--- a/test/acm/tensorflow-housing-app/kustomization.yaml
+++ b/test/acm/tensorflow-housing-app/kustomization.yaml
@@ -4,22 +4,62 @@ kind: Kustomization
 resources:
 - ../../../acm/registration/near-edge/overlays/tensorflow-housing-app/
 
-namespace: my-test-namespace
+namePrefix: custom-prefix-
 
 patches:
 - patch: |-
     - op: replace
-      path: /spec/channel
-      value: my-test-namespace/tensorflow-housing-app-channel
+      path: /spec/template/metadata/name
+      value: '{{name}}-tensorflow-housing-app'
+    - op: replace
+      path: /spec/template/spec/source/targetRevision
+      value: my-git-branch
+    - op: replace
+      path: /spec/template/spec/source/path
+      value: test/gitops/tensorflow-housing-app/
+    - op: replace
+      path: /spec/template/spec/destination/namespace
+      value: custom-app-namespace
   target:
-    kind: Subscription
+    kind: ApplicationSet
 - patch: |-
     - op: replace
-      path: /spec/pathname
-      value: https://github.com/opendatahub-io/ai-edge
+      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
+      value: custom-app-namespace
+    - op: replace
+      path: /spec/policy-templates/0/objectDefinition/metadata/name
+      value: custom-app-namespace-has-argo-label
   target:
-    kind: Channel
+    kind: Policy
 
-commonAnnotations:
-  apps.open-cluster-management.io/git-branch: my-git-branch
-  apps.open-cluster-management.io/git-path: test/gitops/tensorflow-housing-app/
+replacements:
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: argoproj.io
+      kind: ApplicationSet
+    fieldPaths:
+      - spec.generators.0.clusterDecisionResource.labelSelector.matchLabels.cluster\.open-cluster-management\.io/placement
+- source:
+    kind: Placement
+    group: cluster.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - placementRef.name
+- source:
+    kind: Policy
+    group: policy.open-cluster-management.io
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: policy.open-cluster-management.io
+      kind: PlacementBinding
+    fieldPaths:
+      - subjects.0.name

--- a/test/gitops/bike-rental-app/kustomization.yaml
+++ b/test/gitops/bike-rental-app/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 resources:
 - ../../../acm/odh-edge/apps/bike-rental-app/
 
-namespace: my-test-namespace
+namespace: custom-app-namespace


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-203

## Description
This change moves the GitOps machinery from the ACM AppSubscription model that was used here before, to ACM's integration with the ArgoCD/OpenShift Pipelines pull controller. No changes are needed in the referenced gitops repositories.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've added some kustomize tests to validate that all modifications occur as expected. These can be checked by witnessing that the following command exits with a return code of 0:
```
kustomize build acm/registration/near-edge/test/
```

I have also verified that both examples deploy as expected, and can be deleted as expected also. This can be done using the following command:
```
oc apply -k acm/registration/
```
and then once satisfied, deletion can be achieved using the following:
```
oc delete -k acm/registration/
```

I also tested that ACM section in DEVELOPMENT.md, and associated changes to Makefile and YAML files, works as expected.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
