### PR TITLE
RHOAIENG-868: Fix Skopeo-copy tekton task to read auth credentials

### DIFF
--- a/pipelines/tekton/aiedge-e2e/README.md
+++ b/pipelines/tekton/aiedge-e2e/README.md
@@ -24,11 +24,10 @@ End to end pipeline that supports a workflow to Fetch -> Build -> Test -> Push a
   - Add a robot account to push images and set write Permissions for the robot account on the repositories. ([Quay](https://access.redhat.com/documentation/en-us/red_hat_quay/3.10/html/use_red_hat_quay/use-quay-manage-repo))
   - Download the Kubernetes Secret of the robot account and store it in a YAML file.
 - Inspect the file with the pull secret and note the name of the secret, or edit it.
-- Create the secret and link it to the `pipeline` Service Account that was created by the Red Hat OpenShift Pipelines operator using a Tekton Config. E.g.:
+- Create the secret and apply it. This will allow you to use the Quay Robot kubernetes secret directly as the dockerconfig workspace. E.g.:
 
 ```bash
 oc apply -f <downloaddir>/rhoai-edge-build-secret.yml
-oc secret link pipeline rhoai-edge-build-pull-secret
 ```
 
 #### Data for testing the model inferencing endpoint

--- a/pipelines/tekton/aiedge-e2e/tasks/kustomization.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - kserve-download-model.yaml
 - test-model-rest-svc-task.yaml
 - retrieve-build-image-info.task.yaml
+- skopeo-copy.yaml

--- a/pipelines/tekton/aiedge-e2e/tasks/skopeo-copy.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/skopeo-copy.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: skopeo-copy
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/displayName: "skopeo copy"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    Skopeo is a command line tool for working with remote image registries.
+
+    Skopeo doesn’t require a daemon to be running while performing its operations.
+    In particular, the handy skopeo command called copy will ease the whole image
+    copy operation. The copy command will take care of copying the image from
+    internal.registry to production.registry. If your production registry requires
+    credentials to login in order to push the image, skopeo can handle that as well.
+
+  workspaces:
+    - name: images-url
+  params:
+    - name: srcImageURL
+      description: URL of the image to be copied to the destination registry
+      type: string
+      default: ""
+    - name: destImageURL
+      description: URL of the image where the image from source should be copied to
+      type: string
+      default: ""
+    - name: srcTLSverify
+      description: Verify the TLS on the src registry endpoint
+      type: string
+      default: "true"
+    - name: destTLSverify
+      description: Verify the TLS on the dest registry endpoint
+      type: string
+      default: "true"
+  steps:
+    - name: skopeo-copy
+      env:
+      - name: HOME
+        value: /tekton/home
+      image: quay.io/skopeo/stable:v1
+      script: |
+        # Function to copy multiple images.
+        #
+        copyimages() {
+          filename="$(workspaces.images-url.path)/url.txt"
+          while IFS= read -r line || [ -n "$line" ]
+          do
+            cmd=""
+            for url in $line
+            do
+              # echo $url
+              cmd="$cmd \
+                  $url"
+            done
+            read -ra sourceDest <<<"${cmd}"
+            skopeo copy "${sourceDest[@]}" --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
+            echo "$cmd"
+          done < "$filename"
+        }
+        #
+        # If single image is to be copied then, it can be passed through
+        # params in the taskrun.
+        if [ "$(params.srcImageURL)" != "" ] && [ "$(params.destImageURL)" != "" ] ; then
+          skopeo copy "$(params.srcImageURL)" "$(params.destImageURL)" --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
+        else
+          # If file is provided as a configmap in the workspace then multiple images can be copied.
+          #
+          copyimages
+        fi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532

--- a/pipelines/tekton/aiedge-e2e/tasks/skopeo-copy.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/skopeo-copy.yaml
@@ -1,3 +1,5 @@
+
+
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
@@ -22,6 +24,12 @@ spec:
 
   workspaces:
     - name: images-url
+    - name: dockerconfig
+      description: >-
+        An optional workspace that allows providing a .docker/config.json file
+        for Skopeo to access the container registry.
+        The file should be placed at the root of the Workspace with name config.json.
+      optional: true
   params:
     - name: srcImageURL
       description: URL of the image to be copied to the destination registry
@@ -64,6 +72,25 @@ spec:
             echo "$cmd"
           done < "$filename"
         }
+
+        if [[ "$(workspaces.dockerconfig.bound)" == "true" ]]; then
+
+          # if config.json exists at workspace root, we use that
+          if test -f "$(workspaces.dockerconfig.path)/config.json"; then
+            export REGISTRY_AUTH_FILE="$(workspaces.dockerconfig.path)/config.json"
+
+          # else we look for .dockerconfigjson at the root
+          elif test -f "$(workspaces.dockerconfig.path)/.dockerconfigjson"; then
+            echo "here"
+            cp "$(workspaces.dockerconfig.path)/.dockerconfigjson" "$HOME/.docker/config.json"
+            export REGISTRY_AUTH_FILE="$HOME/.docker/config.json"
+
+          # need to error out if neither files are present
+          else
+            echo "neither 'config.json' nor '.dockerconfigjson' found at workspace root"
+            exit 1
+          fi
+        fi
         #
         # If single image is to be copied then, it can be passed through
         # params in the taskrun.

--- a/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
+++ b/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipeline.yaml
@@ -157,11 +157,14 @@ spec:
     runAfter:
     - record-image
     taskRef:
-      kind: ClusterTask
+      kind: Task
       name: skopeo-copy
     workspaces:
     - name: images-url
       workspace: workspace
+    - name: dockerconfig
+      workspace: dockerconfig
   workspaces:
   - name: workspace
   - name: test-data
+  - name: dockerconfig

--- a/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipelinerun-bike-rental.yaml
+++ b/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipelinerun-bike-rental.yaml
@@ -19,6 +19,9 @@ spec:
   serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:
+  - secret: 
+      secretName: rhoai-edge-secret
+    name: dockerconfig
   - emptyDir: {}
     name: workspace
   - configMap:

--- a/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipelinerun-bike-rental.yaml
+++ b/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipelinerun-bike-rental.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 1h0m0s
   workspaces:
   - secret: 
-      secretName: rhoai-edge-secret
+      secretName: rhoai-edge-build-pull-secret
     name: dockerconfig
   - emptyDir: {}
     name: workspace

--- a/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipelinerun-tensorflow-housing.yaml
+++ b/pipelines/tekton/test-mlflow-image-pipeline/test-mlflow-image-pipelinerun-tensorflow-housing.yaml
@@ -19,6 +19,9 @@ spec:
   serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:
+  - secret: 
+      secretName: rhoai-edge-build-pull-secret
+    name: dockerconfig
   - emptyDir: {}
     name: workspace
   - configMap:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes the Skopeo-copy tekton task to read through the credentials present in dockerconfig, there by allowing authenticate the registries and push the built images to it.

JIRA issue: https://issues.redhat.com/browse/RHOAIENG-868?filter=-1

## Description
Modified the Skopeo-copy tekton but adding scripts to read throught dockerconfig files and to fetch the credentials out of it.

## How Has This Been Tested?
- Following the readme provided mounted all the required kubernetes resources on to the cluster, along with modified tekton task - Skopeo-copy, pipeline and pipelineruns.
- Created a quay repository and robot account to access the repository. Downloaded the credentials of the robot account and stored it in file rhoai-edge-build-secret.yml along with credentials of the internal registry where the built image resides. 
- Mounted this secret file on to the cluster
- Started the pipelinerun and the skopeo-copy step passed successfully.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
