### PR TITLE
RHOAIENG-1869 - Migrate PR check from build and test pipelines into e…

### DIFF
--- a/pipelines/tekton/aiedge-e2e/kustomization.yaml
+++ b/pipelines/tekton/aiedge-e2e/kustomization.yaml
@@ -5,4 +5,5 @@ commonLabels:
   app.kubernetes.io/part-of: rhoai-edge-pipelines
 resources:
 - tasks/
+- test-data/
 - aiedge-e2e.pipeline.yaml

--- a/pipelines/tekton/aiedge-e2e/test-data/bike-rentals-test-data-cm.yaml
+++ b/pipelines/tekton/aiedge-e2e/test-data/bike-rentals-test-data-cm.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: bike-rentals-test-data
+
+data:
+  data.json: |+
+    {"dataframe_split": {"columns":[ "day", "mnth", "year", "season","holiday", "weekday", "workingday", "weathersit", "temp", "hum", "windspeed" ], "data":[[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]]}}
+
+  output.json: '{"predictions": [331]}'

--- a/pipelines/tekton/aiedge-e2e/test-data/kustomization.yaml
+++ b/pipelines/tekton/aiedge-e2e/test-data/kustomization.yaml
@@ -1,0 +1,5 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+- bike-rentals-test-data-cm.yaml
+- tensorflow-housing-test-data-cm.yaml

--- a/pipelines/tekton/aiedge-e2e/test-data/tensorflow-housing-test-data-cm.yaml
+++ b/pipelines/tekton/aiedge-e2e/test-data/tensorflow-housing-test-data-cm.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tensorflow-housing-test-data
+
+data:
+  data.json: |+
+    { "instances": [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]] }
+
+  output.json: '{"predictions": [-28.763992309570312]}'

--- a/test/shell-pipeline-tests/README.md
+++ b/test/shell-pipeline-tests/README.md
@@ -19,17 +19,18 @@ For local execution, these environment variables need to be set:
 * **CUSTOM_AWS_SECRET_PATH** - Directory where credentials for the AWS S3 bucket are stored. S3 bucket is used as a source of the AI model. The directory should have 2 files:
   * accessKey - containing the access key, sometimes also called access key ID
   * secretAccessKey - containing the secret access key
-* **CUSTOM_QUAY_SECRET_PATH** - Directory where credentials for the Quay repository are stored. The repository is used to publish the image after it is tested. The directory should contain the file:
-  * dockerconfigjson - without the '.' (dot), containing the full docker config.json with authentication to Quay.io or another registry
+* **CUSTOM_IMAGE_REGISTRY_SECRET_PATH** - Directory where credentials for the image repository (e.g. Quay) are stored. This repository is used to publish the image after it is tested. The pipeline uses [basic-auth](https://tekton.dev/docs/pipelines/auth/#configuring-basic-auth-authentication-for-docker) for authentication. The directory should contain the files:
+  * username - containing the username of the account used to access the image registry
+  * password - containing the password used to access the image registry
 
 After the credentials are configured, you can run the pipeline tests using:
 
 ```shell
-ARTIFACT_DIR=./artifacts CUSTOM_AWS_SECRET_PATH=./secrets CUSTOM_QUAY_SECRET_PATH=./secrets ./openvino-bike-rentals/pipelines-test-openvino-bike-rentals.sh
+ARTIFACT_DIR=./artifacts CUSTOM_AWS_SECRET_PATH=./secrets CUSTOM_IMAGE_REGISTRY_SECRET_PATH=./secrets ./openvino-bike-rentals/pipelines-test-openvino-bike-rentals.sh
 ```
 and
 ```shell
-ARTIFACT_DIR=./artifacts CUSTOM_AWS_SECRET_PATH=./secrets CUSTOM_QUAY_SECRET_PATH=./secrets ./tensorflow-housing/pipelines-test-tensorflow-housing.sh
+ARTIFACT_DIR=./artifacts CUSTOM_AWS_SECRET_PATH=./secrets CUSTOM_IMAGE_REGISTRY_SECRET_PATH=./secrets ./tensorflow-housing/pipelines-test-tensorflow-housing.sh
 ```
 
 This would put all the logs into the `$PWD/artifacts` directory and it also expects all the credential files to be stored under the `$PWD/secrets` directory.

--- a/test/shell-pipeline-tests/common.sh
+++ b/test/shell-pipeline-tests/common.sh
@@ -56,3 +56,17 @@ function createS3Secret() {
     sed -i "s|{{ S3_ENDPOINT__https://example.amazonaws.com/ }}|https://s3.us-west-1.amazonaws.com|" "$AWS_SECRET_PATH"
     sed -i "s|{{ S3_REGION__us-west-1 }}|us-west-1|" "$AWS_SECRET_PATH"
 }
+
+function createImageRegistrySecret() {
+    local -r IMAGE_REGISTRY_SECRET_PATH_TEMPLATE=$1
+    local -r IMAGE_REGISTRY_SECRET_PATH=$2
+
+    local -r AI_EDGE_IMAGE_REGISTRY_OPENSHIFT_CI_SECRET_PATH="${CUSTOM_IMAGE_REGISTRY_SECRET_PATH:-/secrets/ai-edge-quay}"
+    local -r USERNAME=$(cat "$AI_EDGE_IMAGE_REGISTRY_OPENSHIFT_CI_SECRET_PATH"/username)
+    local -r PASSWORD=$(cat "$AI_EDGE_IMAGE_REGISTRY_OPENSHIFT_CI_SECRET_PATH"/password)
+
+    cp "$IMAGE_REGISTRY_SECRET_PATH_TEMPLATE" "$IMAGE_REGISTRY_SECRET_PATH"
+
+    sed -i "s|{{ IMAGE_REGISTRY_USERNAME }}|${USERNAME}|" "$IMAGE_REGISTRY_SECRET_PATH"
+    sed -i "s|{{ IMAGE_REGISTRY_PASSWORD }}|${PASSWORD}|" "$IMAGE_REGISTRY_SECRET_PATH"
+}

--- a/test/shell-pipeline-tests/openvino-bike-rentals/pipelines-test-openvino-bike-rentals.sh
+++ b/test/shell-pipeline-tests/openvino-bike-rentals/pipelines-test-openvino-bike-rentals.sh
@@ -10,31 +10,40 @@ oc new-project "$NAMESPACE"
 
 echo "Waiting for OpenShift Pipelines operator to be fully installed"
 waitForOpResult 60 "True" "N/A" "oc get tektonconfig -n openshift-operators config -o jsonpath={.status.conditions[?\(@.type==\'Ready\'\)].status}"
+waitForOpResult 10 "pipeline" "N/A" "oc get serviceaccount -o=custom-columns=NAME:.metadata.name | grep pipeline"
 
-##### BUILD CONTAINER IMAGE PIPELINE #####
-BUILD_CONTAINER_IMAGE_PIPELINE_PATH="$PIPELINES_DIR"/tekton/build-container-image-pipeline
+##### AIEDGE E2E PIPELINE
+AIEDGE_E2E_PIPELINE_DIR_PATH="$PIPELINES_DIR"/tekton/aiedge-e2e
 
-AWS_SECRET_PATH_TEMPLATE="$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/aws-env.yaml
-AWS_SECRET_PATH="$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/aws-env-overridden.yaml
+AWS_SECRET_PATH_TEMPLATE="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-s3.secret.yaml.template
+AWS_SECRET_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-s3.secret.yaml
 
 createS3Secret "$AWS_SECRET_PATH_TEMPLATE" "$AWS_SECRET_PATH"
 
 oc create -f "$AWS_SECRET_PATH"
 
+IMAGE_REGISTRY_SECRET_PATH_TEMPLATE="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-image-registry.yaml.template
+IMAGE_REGISTRY_SECRET_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-image-registry.yaml
+
+createImageRegistrySecret "$IMAGE_REGISTRY_SECRET_PATH_TEMPLATE" "$IMAGE_REGISTRY_SECRET_PATH"
+
+oc create -f "$IMAGE_REGISTRY_SECRET_PATH"
+oc secret link pipeline credentials-image-registry
+
 ## oc apply -k pipelines
-oc apply -k "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/
+oc apply -k "$AIEDGE_E2E_PIPELINE_DIR_PATH"/
 
 ## prepare parameters
-cp "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-bike-rentals.yaml "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-bike-rentals-overridden.yaml
-sed -i "s|value: rhoai-edge-models|value: rhoai-edge-models-ci|" "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-bike-rentals-overridden.yaml
-sed -i "s|value: \"git\"|value: \"s3\"|" "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-bike-rentals-overridden.yaml
-sed -i "s|value: pipelines/models/|value: \"\"|" "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-bike-rentals-overridden.yaml
+AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.pipelinerun-overridden.yaml
+cp "$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.pipelinerun.yaml "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|value: rhoai-edge-models|value: rhoai-edge-models-ci|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|value: pipelines/models/|value: \"\"|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 
 ## oc create pipeline run
-oc create -f "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-bike-rentals-overridden.yaml
+oc create -f "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 sleep 5 # Just to have the startTime field available
 
-PIPELINE_RUN_NAME=$(oc get pipelinerun --sort-by={.status.startTime} -o=custom-columns=NAME:.metadata.name | grep "build.*bike" | tail -n 1)
+PIPELINE_RUN_NAME=$(oc get pipelinerun --sort-by={.status.startTime} -o=custom-columns=NAME:.metadata.name | grep "aiedge-e2e-.*" | tail -n 1)
 
 if [[ $PIPELINE_RUN_NAME == "" ]]; then
   echo "Could not find any pipeline run"
@@ -48,41 +57,8 @@ PIPELINE_RUN_RESULT=$?
 saveArtifacts "$PIPELINE_RUN_NAME"
 
 if [[ $PIPELINE_RUN_RESULT != 0 ]]; then
-  echo "Build pipeline failed, aborting further tests"
+  echo "The pipeline failed"
   exit 1
+else
+  echo "The pipeline finished successfully"
 fi
-
-
-##### TEST MLFLOW IMAGE PIPELINE #####
-TEST_MLFLOW_IMAGE_PIPELINE_PATH="$PIPELINES_DIR"/tekton/test-mlflow-image-pipeline
-
-AI_EDGE_QUAY_SECRET_OPENSHIFT_CI_PATH="${CUSTOM_QUAY_SECRET_PATH:-/secrets/ai-edge-quay}"
-oc create secret generic rhoai-edge-openshift-ci-secret --from-file=.dockerconfigjson="$AI_EDGE_QUAY_SECRET_OPENSHIFT_CI_PATH"/dockerconfigjson --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | oc apply -f -
-oc secret link pipeline rhoai-edge-openshift-ci-secret
-
-## oc apply -k pipelines
-oc apply -k "$TEST_MLFLOW_IMAGE_PIPELINE_PATH"/
-
-## oc create pipeline run
-oc create -f "$TEST_MLFLOW_IMAGE_PIPELINE_PATH"/test-mlflow-image-pipelinerun-bike-rental.yaml
-sleep 5 # Just to have the startTime field available
-
-PIPELINE_RUN_NAME=$(oc get pipelinerun --sort-by={.status.startTime} -o=custom-columns=NAME:.metadata.name | grep "test.*bike" | tail -n 1)
-
-if [[ $PIPELINE_RUN_NAME == "" ]]; then
-  echo "Could not find any pipeline run"
-  exit 1
-fi
-
-## wait for the result
-waitForOpResult 200 "True" "False" "oc get pipelinerun $PIPELINE_RUN_NAME -o jsonpath={.status.conditions[?\(@.type==\'Succeeded\'\)].status}"
-PIPELINE_RUN_RESULT=$?
-
-saveArtifacts "$PIPELINE_RUN_NAME"
-
-if [[ $PIPELINE_RUN_RESULT != 0 ]]; then
-  echo "Test pipeline failed, aborting further tests"
-  exit 1
-fi
-
-echo "All pipelines finished successfully"

--- a/test/shell-pipeline-tests/tensorflow-housing/pipelines-test-tensorflow-housing.sh
+++ b/test/shell-pipeline-tests/tensorflow-housing/pipelines-test-tensorflow-housing.sh
@@ -10,29 +10,44 @@ oc new-project "$NAMESPACE"
 
 echo "Waiting for OpenShift Pipelines operator to be fully installed"
 waitForOpResult 60 "True" "N/A" "oc get tektonconfig -n openshift-operators config -o jsonpath={.status.conditions[?\(@.type==\'Ready\'\)].status}"
+waitForOpResult 10 "pipeline" "N/A" "oc get serviceaccount -o=custom-columns=NAME:.metadata.name | grep pipeline"
 
-##### BUILD CONTAINER IMAGE PIPELINE #####
-BUILD_CONTAINER_IMAGE_PIPELINE_PATH="$PIPELINES_DIR"/tekton/build-container-image-pipeline
+##### AIEDGE E2E PIPELINE
+AIEDGE_E2E_PIPELINE_DIR_PATH="$PIPELINES_DIR"/tekton/aiedge-e2e
 
-AWS_SECRET_PATH_TEMPLATE="$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/aws-env.yaml
-AWS_SECRET_PATH="$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/aws-env-overridden.yaml
+AWS_SECRET_PATH_TEMPLATE="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-s3.secret.yaml.template
+AWS_SECRET_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-s3.secret.yaml
 
 createS3Secret "$AWS_SECRET_PATH_TEMPLATE" "$AWS_SECRET_PATH"
 
 oc create -f "$AWS_SECRET_PATH"
 
+IMAGE_REGISTRY_SECRET_PATH_TEMPLATE="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-image-registry.yaml.template
+IMAGE_REGISTRY_SECRET_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/templates/credentials-image-registry.yaml
+
+createImageRegistrySecret "$IMAGE_REGISTRY_SECRET_PATH_TEMPLATE" "$IMAGE_REGISTRY_SECRET_PATH"
+
+oc create -f "$IMAGE_REGISTRY_SECRET_PATH"
+oc secret link pipeline credentials-image-registry
+
 ## oc apply -k pipelines
-oc apply -k "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/
+oc apply -k "$AIEDGE_E2E_PIPELINE_DIR_PATH"/
 
 ## prepare parameters
-cp "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-tensorflow-housing.yaml "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-tensorflow-housing-overridden.yaml
-sed -i "s|value: rhoai-edge-models|value: rhoai-edge-models-ci|" "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-tensorflow-housing-overridden.yaml
+AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.pipelinerun-overridden.yaml
+cp "$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.pipelinerun.yaml "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|value: rhoai-edge-models|value: rhoai-edge-models-ci|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|value: bike-rentals-auto-ml|value: tensorflow-housing|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|Containerfile.seldonio.mlserver.mlflow|Containerfile.openvino.mlserver.mlflow|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|value: pipelines/models/|value: \"\"|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|\"invocations\"|\"v1/models/tensorflow-housing/versions/1:predict\"|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|name: bike-rentals-test-data|name: tensorflow-housing-test-data|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 
 ## oc create pipeline run
-oc create -f "$BUILD_CONTAINER_IMAGE_PIPELINE_PATH"/build-container-image-pipelinerun-tensorflow-housing-overridden.yaml
+oc create -f "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 sleep 5 # Just to have the startTime field available
 
-PIPELINE_RUN_NAME=$(oc get pipelinerun --sort-by={.status.startTime} -o=custom-columns=NAME:.metadata.name | grep "build.*housing" | tail -n 1)
+PIPELINE_RUN_NAME=$(oc get pipelinerun --sort-by={.status.startTime} -o=custom-columns=NAME:.metadata.name | grep "aiedge-e2e-.*" | tail -n 1)
 
 if [[ $PIPELINE_RUN_NAME == "" ]]; then
   echo "Could not find any pipeline run"
@@ -46,41 +61,8 @@ PIPELINE_RUN_RESULT=$?
 saveArtifacts "$PIPELINE_RUN_NAME"
 
 if [[ $PIPELINE_RUN_RESULT != 0 ]]; then
-  echo "Build pipeline failed, aborting further tests"
+  echo "The pipeline failed"
   exit 1
+else
+  echo "The pipeline finished successfully"
 fi
-
-
-##### TEST MLFLOW IMAGE PIPELINE #####
-TEST_MLFLOW_IMAGE_PIPELINE_PATH="$PIPELINES_DIR"/tekton/test-mlflow-image-pipeline
-
-AI_EDGE_QUAY_SECRET_OPENSHIFT_CI_PATH="${CUSTOM_QUAY_SECRET_PATH:-/secrets/ai-edge-quay}"
-oc create secret generic rhoai-edge-openshift-ci-secret --from-file=.dockerconfigjson="$AI_EDGE_QUAY_SECRET_OPENSHIFT_CI_PATH"/dockerconfigjson --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | oc apply -f -
-oc secret link pipeline rhoai-edge-openshift-ci-secret
-
-## oc apply -k pipelines
-oc apply -k "$TEST_MLFLOW_IMAGE_PIPELINE_PATH"/
-
-## oc create pipeline run
-oc create -f "$TEST_MLFLOW_IMAGE_PIPELINE_PATH"/test-mlflow-image-pipelinerun-tensorflow-housing.yaml
-sleep 5 # Just to have the startTime field available
-
-PIPELINE_RUN_NAME=$(oc get pipelinerun --sort-by={.status.startTime} -o=custom-columns=NAME:.metadata.name | grep "test.*housing" | tail -n 1)
-
-if [[ $PIPELINE_RUN_NAME == "" ]]; then
-  echo "Could not find any pipeline run"
-  exit 1
-fi
-
-## wait for the result
-waitForOpResult 200 "True" "False" "oc get pipelinerun $PIPELINE_RUN_NAME -o jsonpath={.status.conditions[?\(@.type==\'Succeeded\'\)].status}"
-PIPELINE_RUN_RESULT=$?
-
-saveArtifacts "$PIPELINE_RUN_NAME"
-
-if [[ $PIPELINE_RUN_RESULT != 0 ]]; then
-  echo "Test pipeline failed, aborting further tests"
-  exit 1
-fi
-
-echo "All pipelines finished successfully"


### PR DESCRIPTION
…2e pipeline

**JIRA:** [RHOAIENG-1869](https://issues.redhat.com/browse/RHOAIENG-1869)

## Description
This migrates the PR check to test the single e2e pipeline instead of 2 separate pipelines (build-container-image-pipeline and test-mlflow-image-pipeline)

It also adds a new function to be able to create a `basic-auth` secret instead of a `kubernetes.io/dockerconfigjson` secret as this is what the pipeline uses now.

## How Has This Been Tested?
Locally using a separate cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
