### PR TITLE
Add copy-model-from-pvc Task to aiedge-e2e directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,10 @@ You can set the `SIZE` and `PVC` values aswell
 make MODEL_PATH="PATH_TO_A_FILE" NAME=my-model SIZE=1G PVC=my-new-PVC create
 ```
 
-In `pipelines/tekton/build-container-image-pipeline` you can set the
-`fetch-model` to `pvc` for the pipeline to copy the file from the
-`model-workspace` which can be set to the PVC created in the last step
+You can then use the [copy-model-from-pvc](pipelines/tekton/aiedge-e2e/tasks/copy-model-from-pvc.yaml) task to
+copy the model from the `model-workspace`, which can be set to the PVC created in the last step, to the `buildah-cache` workspace,
+which is then used by the `buildah` task in the pipeline. [copy-model-from-pvc](pipelines/tekton/aiedge-e2e/tasks/copy-model-from-pvc.yaml) task
+is not included in the pipeline by default, you have to add it yourself. 
 
 ## Contributing
 

--- a/pipelines/tekton/aiedge-e2e/tasks/copy-model-from-pvc.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/copy-model-from-pvc.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: copy-model-from-pvc
+spec:
+  description: This Task can be used to copy a model from another pvc
+  params:
+  - name: model-name
+    type: string
+  steps:
+  - name: copy-model-from-pvc
+    image: quay.io/opendatahub/kserve-storage-initializer:v0.11
+    script: |
+      SOURCE_PATH="$(workspaces.source-workspace.path)/model_dir/$(params.model-name)"
+
+      DEST_PATH="$(workspaces.destination-workspace.path)/model_dir/$(params.model-name)"
+
+      echo "Copying model file $SOURCE_PATH"
+      echo "to $DEST_PATH"
+
+      DIR_PATH="$(dirname $(workspaces.destination-workspace.path)/model_dir/$(params.model-name))"
+
+      mkdir -p $DIR_PATH
+
+      cp -r $SOURCE_PATH $DEST_PATH
+  workspaces:
+  - description: The workspace the model is being copied from
+    name: source-workspace
+  - description: The workspace the model is being copied to
+    name: destination-workspace

--- a/pipelines/tekton/aiedge-e2e/tasks/kustomization.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - kserve-download-model.yaml
 - test-model-rest-svc-task.yaml
 - retrieve-build-image-info.task.yaml
+- copy-model-from-pvc.yaml


### PR DESCRIPTION
## Description
We are deprecating the `build-container-image-pipeline` and `test-mlflow-image-pipeline` and need to preserve the `copy-model-from-pvc` Task with the aiedge-e2e pipeline

## How Has This Been Tested
Confirmed that `kustomize build pipelines/tekton/aiedge-e2e/tasks/` includes the new task in the output

## Merge criteria:
There are no issues with the kustomize manifest that applies the tasks to the cluster

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
