### PR TITLE
Fix the ApplicationSet clusterDefinition generator

### DIFF
--- a/acm/registration/near-edge/base/near-edge.yaml
+++ b/acm/registration/near-edge/base/near-edge.yaml
@@ -65,7 +65,7 @@ metadata:
 spec:
   generators:
     - clusterDecisionResource:
-        configMapRef: ocm-placement-generator
+        configMapRef: acm-placement
         labelSelector:
           matchLabels:
             cluster.open-cluster-management.io/placement: placement


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In the `ApplicationSet`, the name of the `ConfigMap` referenced in the cluster decision resource generator was incorrect so syncing of the applications was broken. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This was tested by following the README on a rosa hub cluster and an OpenShift local edge cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
