### PR TITLE
RHOAIENG-3233 - Include events and deployment logs in the shell-pipel…

### DIFF
--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -32,6 +32,8 @@ spec:
     value: "invocations"
   - name: target-imagerepo
     value: rhoai-edge
+  - name: upon-end
+    value: "delete"
   pipelineRef:
     name: aiedge-e2e
   serviceAccountName: pipeline

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -260,7 +260,7 @@ spec:
               - image: $(params.model-name):$(params.model-version)
                 name: $(params.model-name)-$(params.model-version)
                 livenessProbe:
-                  failureThreshold: 8
+                  failureThreshold: 10
                   httpGet:
                     path: /v2/health/live
                     port: 8080
@@ -268,7 +268,7 @@ spec:
                   periodSeconds: 5
                   successThreshold: 1
                 readinessProbe:
-                  failureThreshold: 8
+                  failureThreshold: 10
                   httpGet:
                     path: /v2/models/$(params.model-name)/ready
                     port: 8080

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
@@ -34,6 +34,8 @@ spec:
     value: "v1/models/tensorflow-housing/versions/1:predict"
   - name: target-imagerepo
     value: rhoai-edge
+  - name: upon-end
+    value: "delete"
   pipelineRef:
     name: aiedge-e2e
   serviceAccountName: pipeline

--- a/test/shell-pipeline-tests/common.sh
+++ b/test/shell-pipeline-tests/common.sh
@@ -34,7 +34,10 @@ function saveArtifacts() {
     oc get pipelinerun $PIPELINE_RUN_NAME -o yaml > "${LOGS_DIR}"/pipelineRuns.txt
     oc get task -o yaml > "${LOGS_DIR}"/tasks.txt
     oc get taskrun -l "tekton.dev/pipelineRun=$PIPELINE_RUN_NAME" -o yaml > "${LOGS_DIR}"/taskRuns.txt
-    oc logs -l "tekton.dev/pipelineRun=$PIPELINE_RUN_NAME" --all-containers --prefix --tail=-1 > "${LOGS_DIR}"/logs.txt
+    oc logs -l "tekton.dev/pipelineRun=$PIPELINE_RUN_NAME" --all-containers --prefix --tail=-1 > "${LOGS_DIR}"/pipelineLogs.txt
+    oc get deployment -o yaml > "${LOGS_DIR}"/deployments.txt
+    oc logs -l '!tekton.dev/pipelineRun' --all-containers --prefix --tail=-1 > "${LOGS_DIR}"/deploymentLogs.txt
+    oc events > "${LOGS_DIR}"/events.txt
 }
 
 function createS3Secret() {

--- a/test/shell-pipeline-tests/openvino-tensorflow-housing/pipelines-test-openvino-tensorflow-housing.sh
+++ b/test/shell-pipeline-tests/openvino-tensorflow-housing/pipelines-test-openvino-tensorflow-housing.sh
@@ -36,6 +36,7 @@ oc apply -k "$AIEDGE_E2E_PIPELINE_DIR_PATH"/
 ## prepare parameters
 AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.pipelinerun-overridden.yaml
 cp "$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.tensorflow-housing.pipelinerun.yaml "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|value: \"delete\"|value: \"keep\"|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 
 ## oc create pipeline run
 oc create -f "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"

--- a/test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh
+++ b/test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh
@@ -37,6 +37,7 @@ oc apply -k "$AIEDGE_E2E_PIPELINE_DIR_PATH"/
 AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.pipelinerun-overridden.yaml
 cp "$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.bike-rentals.pipelinerun.yaml "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 sed -i "s|value: rhoai-edge-models|value: rhoai-edge-models-ci|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+sed -i "s|value: \"delete\"|value: \"keep\"|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 
 ## oc create pipeline run
 oc create -f "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"


### PR DESCRIPTION
…ine-tests
**JIRA:** [RHOAIENG-3233](https://issues.redhat.com/browse/RHOAIENG-3233)
## Description
This adds:
* Archiving events of the namespace at the end of the scenario (events.txt)
* Archiving deployment and its pod's log (deployments.txt and deploymentLogs.txt)
  * This required including the `upon-end` parameter in the pipeline run even though it has a default value so it can be easily overwritten using sed to `keep` the deployment running, otherwise logs would be lost or obtained just in case the pod termination would be long enough and end only after the pipeline finishes. Without this change it would need more complicated manipulation of the yaml file using tools such as `yq` etc.

## How Has This Been Tested?
Locally + using a PR check.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
