### PR TITLE
Makefile: Add support to include vars from local env var file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ aws-storage-config
 pipelines/tekton/build-container-image-pipeline/build-container-image-aws-creds-real.yaml
 pipelines/tekton/build-container-image-pipeline/aws-env-real.yaml
 oc-debug-pod.yaml
+
+
+# Local Makefile variable override file name.
+*local.vars.mk

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,3 +84,33 @@ make -s -e GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" \
      CUSTOM_APP_NAMESPACE=my-test-namespace \
      test-acm-bike-rental-app-generate  | oc apply -f -
 ```
+
+## Using a local.vars.mk file to override Makefile variables for your development environment
+To support the ability for a developer to customize the Makefile execution for their development environment, you can create a `local.vars.mk` file in the root of this repo to specify custom values matching your environment.  
+
+```
+$ cat local.vars.mk
+AWS_SECRET_ACCESS_KEY=MYSECRETACCESSKEYAWS
+AWS_ACCESS_KEY_ID=a1b2c3d4e5f6g7h8i9j0abcdefghijklmnopqrstuv
+S3_REGION=us-east-9
+S3_ENDPOINT=https://s3.amazonaws.com
+IMAGE_REGISTRY_USERNAME=my+robot+username
+IMAGE_REGISTRY_PASSWORD=<IMAGE-REGISTRY-PASSWORD>
+
+$ make 
+```
+
+If you need to use a different variable file for multiple environments, you can specify a different file that will be used as the local vars file
+
+```
+$ cat foo-storage.local.vars.mk
+AWS_SECRET_ACCESS_KEY=MYSECRETACCESSKEYFOO
+AWS_ACCESS_KEY_ID=a1b2c3d4e5f6g7h8i9j0abcdefghijklmnopqrstuv
+S3_REGION=us-west-4
+S3_ENDPOINT=https://s3.foo-object-storage.com
+IMAGE_REGISTRY_USERNAME=my+robot+username+foo
+IMAGE_REGISTRY_PASSWORD=<IMAGE-REGISTRY-PASSWORD>
+
+$ make MAKE_ENV_FILE=foo-storage.local.vars.mk
+```
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# Read any custom variables overrides from a local.vars.mk file.  This will only be read if it exists in the 
+# same directory as this Makefile.  Variables can be specified in the standard format supported by 
+# GNU Make since include process Makefiles
+# Standard variables override would include anything you would pass at runtime that is different from the defaults specified in this file
+MAKE_ENV_FILE = local.vars.mk
+-include $(MAKE_ENV_FILE)
+
 .PHONY: install install/observability-core install/observability-edge test-acm-%-generate test go-test go-test-setup
 
 install: install/observability-core install/observability-edge


### PR DESCRIPTION


## Description
Adds support for passing Make variables via a local env var file instead of on the command line

## How Has This Been Tested?
Successfully ran `make` against `go-test` and `go-test-setup` without any variables on the CLI

## Merge criteria:
CI runs and local `make` execution works without any issues

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
