### PR TITLE
Heredoc in containerfile is supported only since 1.33.0

### DIFF
--- a/pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow
+++ b/pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow
@@ -18,15 +18,8 @@ RUN mkdir /models && chown ovms:ovms /models
 # CHANGE THIS LINE TO MATCH YOUR MODEL
 COPY --chown=ovms:ovms $MODEL_DIR /models/1
 
-RUN <<EOF
-    # Not deleting this file causes a bug
-    if echo "${MODEL_DIR}" | grep -q "tf2model"; then rm -f /models/1/fingerprint.pb; fi
-
-    chmod o+rwX /models/1
-
-    # https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html#use-uid_create-images
-    chgrp -R 0 /models/1 && chmod -R g=u /models/1
-EOF
+                                # Not deleting this file causes a bug                                                # https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html#use-uid_create-images
+RUN if echo "${MODEL_DIR}" | grep -q "tf2model"; then rm -f /models/1/fingerprint.pb; fi && chmod o+rwX /models/1 && chgrp -R 0 /models/1 && chmod -R g=u /models/1
 
 EXPOSE $REST_PORT $GRPC_PORT
 

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -208,7 +208,7 @@ spec:
     - name: IMAGE
       value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)
     - name: BUILDER_IMAGE
-      value: registry.redhat.io/rhel8/buildah@sha256:0a86ecbdfbe86e9d225b7fe4b090a0dd6d323f8afdfdf2bd933ff223ddb53320
+      value: registry.redhat.io/rhel8/buildah@sha256:f5521de9445a04054c386707b774d7d534556c03b29ba4c91cfddfa979cf761c
     - name: STORAGE_DRIVER
       value: vfs
     - name: DOCKERFILE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Switches heredoc to a one-liner so we have just one layer. Heredoc is only compatible in [Buildah 1.33.0](https://buildah.io/releases/#buildah-version-1330-release-announcement) but the latest rhel8 image has just 1.31.
* Updates the buildah image to the [latest](https://catalog.redhat.com/software/containers/rhel8/buildah/5dca3d76dd19c71643b226d5?image=659525ba18d1f0c9c2d52ba6&architecture=amd64) one.

## How Has This Been Tested?
Locally, PR check currently doesn't run the containerfiles from the same branch. I will investigate whether it is possible to obtain the PR's author and fork.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
