### PR TITLE
fix: path to pipelinerun renamed in go e2e-tests

### DIFF
--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	AIEdgeE2EPipelineDirectoryRelativePath = "../../../pipelines/tekton/aiedge-e2e"
-	PipelineRunFileRelativePath            = AIEdgeE2EPipelineDirectoryRelativePath + "/aiedge-e2e.pipelinerun.yaml"
+	PipelineRunFileRelativePath            = AIEdgeE2EPipelineDirectoryRelativePath + "/aiedge-e2e.bike-rentals.pipelinerun.yaml"
 )
 
 func CreateContext() context.Context {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The main MLOps pipeline's pipeline run example was renamed. This was not updated in the go e2e-tests and broke them. This fixes that issue.

## Verify steps
- Log into a cluster with `oc`
- Set the list of enviroment variables that are needed for running the tests for both the `go-test` and `go-test-setup` make targets. All of the required fields are listed [here](https://github.com/jackdelahunt/ai-edge/blob/pipeline-testing/Makefile#L37-L44) and [here](https://github.com/jackdelahunt/ai-edge/blob/pipeline-testing/Makefile#L74-L76)
- Run `oc new-project test-namespace`
- Run `make AWS_SECRET=... AWS_ACCESS=...  ... go-test-setup`
- Run `make S3_BUCKET=...  ... go-test`
- All tests should pass

## How Has This Been Tested?


- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
