### PR TITLE
RHOAIENG-3233 - follow-up: Show absolute timestamps for events

### DIFF
--- a/test/shell-pipeline-tests/common.sh
+++ b/test/shell-pipeline-tests/common.sh
@@ -37,7 +37,8 @@ function saveArtifacts() {
     oc logs -l "tekton.dev/pipelineRun=$PIPELINE_RUN_NAME" --all-containers --prefix --tail=-1 > "${LOGS_DIR}"/pipelineLogs.txt
     oc get deployment -o yaml > "${LOGS_DIR}"/deployments.txt
     oc logs -l '!tekton.dev/pipelineRun' --all-containers --prefix --tail=-1 > "${LOGS_DIR}"/deploymentLogs.txt
-    oc events > "${LOGS_DIR}"/events.txt
+    # https://access.redhat.com/solutions/4725511
+    oc get events -o custom-columns="LAST SEEN:{lastTimestamp},FIRST SEEN:{firstTimestamp},COUNT:{count},TYPE:{type},REASON:{reason},KIND:{involvedObject.kind},NAME:{involvedObject.name},SOURCE:{source.component},MESSAGE:{message}" --sort-by={lastTimestamp} > "${LOGS_DIR}"/events.txt
 }
 
 function createS3Secret() {


### PR DESCRIPTION
**JIRA:** [RHOAIENG-3233](https://issues.redhat.com/browse/RHOAIENG-3233)

## Description
A small enhancement to the #205 which adds an absolute timestamp to each event rather than time since the last occurrence.

## How Has This Been Tested?
Locally + PR check.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
