### PR TITLE
RHOAIENG-3359 - Switch rhel8 to ubi9 image in buildah task

### DIFF
--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -208,7 +208,7 @@ spec:
     - name: IMAGE
       value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)
     - name: BUILDER_IMAGE
-      value: registry.redhat.io/rhel8/buildah@sha256:f5521de9445a04054c386707b774d7d534556c03b29ba4c91cfddfa979cf761c
+      value: registry.redhat.io/ubi9/buildah:latest
     - name: STORAGE_DRIVER
       value: vfs
     - name: DOCKERFILE


### PR DESCRIPTION
**JIRA:** [RHOAIENG-3359](https://issues.redhat.com/browse/RHOAIENG-3359)

## Description
Switches buildah image to use `registry.redhat.io/ubi9/buildah:latest`.

## How Has This Been Tested?
PR check.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
