### PR TITLE
RHOAIENG-2758: Accept one or more target image tags as a param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Read any custom variables overrides from a local.vars.mk file.  This will only be read if it exists in the 
-# same directory as this Makefile.  Variables can be specified in the standard format supported by 
+# Read any custom variables overrides from a local.vars.mk file.  This will only be read if it exists in the
+# same directory as this Makefile.  Variables can be specified in the standard format supported by
 # GNU Make since include process Makefiles
 # Standard variables override would include anything you would pass at runtime that is different from the defaults specified in this file
 MAKE_ENV_FILE = local.vars.mk
@@ -73,19 +73,19 @@ endif
 
 # requires:
 #	S3_BUCKET		- Name of S3 bucket that has the model
-#	TARGET_IMAGE_NAMESPACE	- Image registry namespace that the built model will be pushed to a repository in
 #	NAMESPACE		- Cluster namespace that tests are run in
+#	TARGET_IMAGE_TAGS_JSON	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
 go-test:
 ifndef S3_BUCKET
 	$(error S3_BUCKET is undefined)
 endif
-ifndef TARGET_IMAGE_NAMESPACE
-	$(error TARGET_IMAGE_NAMESPACE is undefined)
-endif
 ifndef NAMESPACE
 	$(error NAMESPACE is undefined)
 endif
-	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_NAMESPACE=${TARGET_IMAGE_NAMESPACE} NAMESPACE=${NAMESPACE} ${GO} test -timeout 30m)
+ifndef TARGET_IMAGE_TAGS_JSON
+	$(error TARGET_IMAGE_TAGS_JSON is undefined)
+endif
+	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} ${GO} test -timeout 30m)
 
 test:
 	@(./test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh)

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ make MODEL_PATH="PATH_TO_A_FILE" NAME=my-model SIZE=1G PVC=my-new-PVC create
 ```
 
 You can then use the [copy-model-from-pvc](pipelines/tekton/aiedge-e2e/tasks/copy-model-from-pvc.yaml) task to
-copy the model from the `model-workspace`, which can be set to the PVC created in the last step, to the `buildah-cache` workspace,
+copy the model from the `model-workspace`, which can be set to the PVC created in the last step, to the `build-workspace-pv` workspace,
 which is then used by the `buildah` task in the pipeline. [copy-model-from-pvc](pipelines/tekton/aiedge-e2e/tasks/copy-model-from-pvc.yaml) task
-is not included in the pipeline by default, you have to add it yourself. 
+is not included in the pipeline by default, you have to add it yourself.
 
 ## Contributing
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -177,6 +177,7 @@ You may also want to change other parameters like:
 * `containerfileRelativePath` - to try a different Containerfile
 * `fetch-model` - to switch between S3 and Git
 * `test-endpoint` - endpoint of the running model server used for testing the inference
+* `target-image-tag-references` - a list of image tag references in image repositories in image registries, that the image should be pushed to
 
 Be sure to also use the correct config map with the test data.
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -188,7 +188,7 @@ oc create -f tekton/aiedge-e2e/aiedge-e2e.pipelinerun.yaml
 ```
 
 > [!IMPORTANT]
-> Since the `buildah-cache` workspace is used to share data between TaskRuns in a PipelineRun, a PersistentVolumeClaim type VolumeSource is required to fulfill it properly.
+> Since the `build-workspace-pv` workspace is used to share data between TaskRuns in a PipelineRun, a PersistentVolumeClaim type VolumeSource is required to fulfill it properly.
 > We strongly recommend that this is fulfilled using the `volumeClaimTemplate` approach, rather than the `persistentVolumeClaim` approach.
 > If you must use the `persistentVolumeClaim` approach to re-use an existing PersistentVolumeClaim, then you will likely hit issues if two PipelineRuns for the same model name are executed concurrently (and possibly other corner cases).
 > See the Tekton documentation around [Using PersistentVolumeClaims as VolumeSource](https://tekton.dev/docs/pipelines/workspaces/#using-persistentvolumeclaims-as-volumesource).

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -30,8 +30,11 @@ spec:
     value: "main"
   - name: test-endpoint
     value: "invocations"
-  - name: target-image-tag-reference
-    value: quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)
+  - name: target-image-tag-references
+    value:
+    - quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)
+    - quay.io/rhoai-edge/$(params.model-name):$(params.model-version)
+    - quay.io/rhoai-edge/$(params.model-name):latest
   - name: upon-end
     value: "delete"
   pipelineRef:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -42,7 +42,7 @@ spec:
   serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:
-  - name: buildah-cache
+  - name: build-workspace-pv
     # Have the tekton controller allocate a PVC for each pipeline run that persists for the life of each PipelineRun object.
     # NOTE: This PVC will be deleted by the Tekton controller when the PipelineRun is deleted
     volumeClaimTemplate:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -30,8 +30,8 @@ spec:
     value: "main"
   - name: test-endpoint
     value: "invocations"
-  - name: target-imagerepo
-    value: rhoai-edge
+  - name: target-image-tag-reference
+    value: quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)
   - name: upon-end
     value: "delete"
   pipelineRef:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -127,7 +127,7 @@ spec:
       value: /model_dir-$(params.model-name)/
     workspaces:
     - name: output
-      workspace: buildah-cache
+      workspace: build-workspace-pv
     when:
     - input: "$(params.fetch-model)"
       operator: in
@@ -146,7 +146,7 @@ spec:
       name: kserve-download-model
     workspaces:
     - name: workspace
-      workspace: buildah-cache
+      workspace: build-workspace-pv
     - name: s3-secret
       workspace: s3-secret
     when:
@@ -167,7 +167,7 @@ spec:
       name: git-clone
     workspaces:
     - name: output
-      workspace: buildah-cache
+      workspace: build-workspace-pv
     - name: basic-auth
       workspace: git-basic-auth
   - name: check-model-and-containerfile-exists
@@ -187,7 +187,7 @@ spec:
       name: check-model-and-containerfile-exists
     workspaces:
     - name: workspace
-      workspace: buildah-cache
+      workspace: build-workspace-pv
   - name: create-imagestream
     params:
     - name: SCRIPT
@@ -227,7 +227,7 @@ spec:
       name: buildah
     workspaces:
     - name: source
-      workspace: buildah-cache
+      workspace: build-workspace-pv
   - name: test-container-deploy
     params:
     - name: SCRIPT
@@ -356,7 +356,7 @@ spec:
     - stop-deployment
     workspaces:
     - name: images-url
-      workspace: buildah-cache
+      workspace: build-workspace-pv
   - name: skopeo-copy
     params:
     - name: srcTLSverify
@@ -370,9 +370,9 @@ spec:
       name: skopeo-copy
     workspaces:
     - name: images-url
-      workspace: buildah-cache
+      workspace: build-workspace-pv
   workspaces:
-  - name: buildah-cache
+  - name: build-workspace-pv
   - name: s3-secret
   - name: git-basic-auth
     optional: true

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -51,9 +51,9 @@ spec:
   - default: $(context.pipelineRun.namespace)
     name: target-namespace
     type: string
-  - name: target-image-tag-reference
-    type: string
-    description: "The fully qualified image tag reference to be used for the final image push. E.g. registry.example.com/my-org/ai-model:1.0-1"
+  - name: target-image-tag-references
+    type: array
+    description: "An array of fully qualified image tag references to be used for the final image push. E.g. registry.example.com/my-org/ai-model:1.0-1"
   - name: upon-end
     type: string
     description: "Action to perform on the k8s deployment created to test the model container image. Valid values in [delete, keep, stop]"
@@ -89,9 +89,9 @@ spec:
   - name: internal-registry-url
     description: The tag where the model container image was pushed to in the internal registry (e.g. image-reg...svc:5000/rhoai-models/ai-model:1-232)
     value: $(tasks.build-container.results.IMAGE_URL)
-  - name: target-image-tag-reference
+  - name: target-image-tag-references
     description: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)
-    value: $(tasks.retrieve-build-image-info.results.target-image-tag-reference)
+    value: $(tasks.retrieve-build-image-info.results.target-image-tag-references)
   - name: internal-image-url
     description: The url of the image in the internal registry
     value: $(tasks.retrieve-build-image-info.results.internal-image-url)
@@ -349,17 +349,16 @@ spec:
       value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: pipeline-run-uid
       value: $(context.pipelineRun.uid)
-    - name: target-image-tag-reference
-      value: $(params.target-image-tag-reference)
+    - name: target-image-tag-references
+      value: ["$(params.target-image-tag-references[*])"]
     runAfter:
     - test-model-rest-svc
     - stop-deployment
+    workspaces:
+    - name: images-url
+      workspace: buildah-cache
   - name: skopeo-copy
     params:
-    - name: srcImageURL
-      value: docker://$(tasks.retrieve-build-image-info.results.internal-image-url)
-    - name: destImageURL
-      value: docker://$(params.target-image-tag-reference)
     - name: srcTLSverify
       value: "true"
     - name: destTLSverify
@@ -371,11 +370,10 @@ spec:
       name: skopeo-copy
     workspaces:
     - name: images-url
-      workspace: workspace
+      workspace: buildah-cache
   workspaces:
   - name: buildah-cache
   - name: s3-secret
   - name: git-basic-auth
     optional: true
-  - name: workspace
   - name: test-data

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -51,9 +51,9 @@ spec:
   - default: $(context.pipelineRun.namespace)
     name: target-namespace
     type: string
-  - name: target-imagerepo
+  - name: target-image-tag-reference
     type: string
-    description: "The image registry name where the model container for the final image push. Currently supports using quay.io/<target-imagerepo>"
+    description: "The fully qualified image tag reference to be used for the final image push. E.g. registry.example.com/my-org/ai-model:1.0-1"
   - name: upon-end
     type: string
     description: "Action to perform on the k8s deployment created to test the model container image. Valid values in [delete, keep, stop]"
@@ -89,15 +89,12 @@ spec:
   - name: internal-registry-url
     description: The tag where the model container image was pushed to in the internal registry (e.g. image-reg...svc:5000/rhoai-models/ai-model:1-232)
     value: $(tasks.build-container.results.IMAGE_URL)
-  - name: target-registry-url
-    description: The url of the target registry (e.g. quay.io/rhoai-models/ai-model/)
-    value: $(tasks.retrieve-build-image-info.results.target-registry-url)
+  - name: target-image-tag-reference
+    description: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)
+    value: $(tasks.retrieve-build-image-info.results.target-image-tag-reference)
   - name: internal-image-url
     description: The url of the image in the internal registry
     value: $(tasks.retrieve-build-image-info.results.internal-image-url)
-  - name: target-image-url
-    description: The url of the image in the target registry (e.g. quay.io/rhoai-models/ai-model:1-232)
-    value: $(tasks.retrieve-build-image-info.results.target-image-url)
   - name: internal-image-size
     description: The size of the model container image in the internal registry in bytes
     value: $(tasks.retrieve-build-image-info.results.internal-image-size)
@@ -352,8 +349,8 @@ spec:
       value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: pipeline-run-uid
       value: $(context.pipelineRun.uid)
-    - name: target-registry-url
-      value: quay.io/$(params.target-imagerepo)/$(params.model-name)
+    - name: target-image-tag-reference
+      value: $(params.target-image-tag-reference)
     runAfter:
     - test-model-rest-svc
     - stop-deployment
@@ -362,7 +359,7 @@ spec:
     - name: srcImageURL
       value: docker://$(tasks.retrieve-build-image-info.results.internal-image-url)
     - name: destImageURL
-      value: docker://$(tasks.retrieve-build-image-info.results.target-image-url)
+      value: docker://$(params.target-image-tag-reference)
     - name: srcTLSverify
       value: "true"
     - name: destTLSverify

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
@@ -32,8 +32,11 @@ spec:
     value: "main"
   - name: test-endpoint
     value: "v1/models/tensorflow-housing/versions/1:predict"
-  - name: target-image-tag-reference
-    value: quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)
+  - name: target-image-tag-references
+    value:
+    - quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)
+    - quay.io/rhoai-edge/$(params.model-name):$(params.model-version)
+    - quay.io/rhoai-edge/$(params.model-name):latest
   - name: upon-end
     value: "delete"
   pipelineRef:
@@ -54,8 +57,6 @@ spec:
   - name: s3-secret
     secret:
         secretName: credentials-s3
-  - emptyDir: {}
-    name: workspace
   - configMap:
       name: tensorflow-housing-test-data
     name: test-data

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
@@ -44,7 +44,7 @@ spec:
   serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:
-  - name: buildah-cache
+  - name: build-workspace-pv
     # Have the tekton controller allocate a PVC for each pipeline run that persists for the life of each PipelineRun object.
     # NOTE: This PVC will be deleted by the Tekton controller when the PipelineRun is deleted
     volumeClaimTemplate:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
@@ -32,8 +32,8 @@ spec:
     value: "main"
   - name: test-endpoint
     value: "v1/models/tensorflow-housing/versions/1:predict"
-  - name: target-imagerepo
-    value: rhoai-edge
+  - name: target-image-tag-reference
+    value: quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)
   - name: upon-end
     value: "delete"
   pipelineRef:

--- a/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
@@ -15,11 +15,15 @@ spec:
     type: string
   - name: pipeline-run-uid
     type: string
-  - name: target-image-tag-reference
-    type: string
+  - name: target-image-tag-references
+    type: array
+  workspaces:
+  - name: images-url
   steps:
   - name: get-image-sha
     image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+    args:
+      - "$(params.target-image-tag-references[*])"
     script: |
       #!/usr/bin/env bash
 
@@ -42,7 +46,28 @@ spec:
       echo ;
       oc get -n $(params.namespace) -o jsonpath='{.image.dockerImageMetadata.Config.Labels.io\.buildah\.version}' imagestreamtag/$(params.model-name):$(params.model-version) | tee $(results.internal-image-buildah-version.path) ;
       echo ;
-      echo -n "$(params.target-image-tag-reference)" | tee $(results.target-image-tag-reference.path) ;
+      echo -n "$@" | tee $(results.target-image-tag-references.path) ;
+  - name: build-urls-txt
+    image: registry.access.redhat.com/ubi9/ubi-micro
+    args:
+      - "$(params.target-image-tag-references[*])"
+    script: |
+      #!/usr/bin/env bash
+
+      set -Eeuo pipefail
+
+      # The skopeo-copy task looks for this file in its workspace if the source and destination parameters are
+      # empty. This is what allows pushing to more than one tag from the single taskrun.
+      export URLTXT=$(workspaces.images-url.path)/url.txt
+      export SOURCE_IMAGE_REF=$(cat $(results.internal-image-url.path))
+
+      rm -f ${URLTXT}
+      for target in "$@"; do
+        echo "docker://${SOURCE_IMAGE_REF} docker://${target}" >> "${URLTXT}"
+      done
+
+      echo "Contents of ${URLTXT}:"
+      cat ${URLTXT}
   results:
   - name: model-name
     description: The name of the model
@@ -56,5 +81,5 @@ spec:
     description: The version of buildah used to build the image
   - name: internal-image-url
     description: The url of the image in the internal registry
-  - name: target-image-tag-reference
+  - name: target-image-tag-references
     description: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)

--- a/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
@@ -15,17 +15,19 @@ spec:
     type: string
   - name: pipeline-run-uid
     type: string
-  - name: target-registry-url
+  - name: target-image-tag-reference
     type: string
   steps:
   - name: get-image-sha
     image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     script: |
+      #!/usr/bin/env bash
+
+      set -Eeuo pipefail
+
       echo -n "$(params.model-name)" | tee $(results.model-name.path) ;
       echo ;
       echo -n "$(params.model-version)" | tee $(results.model-version.path) ;
-      echo ;
-      echo -n "$(params.target-registry-url)" | tee $(results.target-registry-url.path) ;
       echo ;
       export DOCKER_IMAGE_REF=$(oc get -n $(params.namespace) -o jsonpath='{.image.dockerImageReference}' imagestreamtag/$(params.model-name):$(params.model-version)) ;
       if [[ $DOCKER_IMAGE_REF != *"$(params.buildah-sha)"* ]]; then
@@ -40,7 +42,7 @@ spec:
       echo ;
       oc get -n $(params.namespace) -o jsonpath='{.image.dockerImageMetadata.Config.Labels.io\.buildah\.version}' imagestreamtag/$(params.model-name):$(params.model-version) | tee $(results.internal-image-buildah-version.path) ;
       echo ;
-      echo -n "$(params.target-registry-url):$(params.model-version)-$(params.pipeline-run-uid)" | tee $(results.target-image-url.path) ;
+      echo -n "$(params.target-image-tag-reference)" | tee $(results.target-image-tag-reference.path) ;
   results:
   - name: model-name
     description: The name of the model
@@ -54,7 +56,5 @@ spec:
     description: The version of buildah used to build the image
   - name: internal-image-url
     description: The url of the image in the internal registry
-  - name: target-registry-url
-    description: The url of the target registry (e.g. quay.io/rhoai-models/ai-model/)
-  - name: target-image-url
-    description: The url of the image in the target registry (e.g. quay.io/rhoai-models/ai-model:1-232)
+  - name: target-image-tag-reference
+    description: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -17,7 +17,7 @@ The following enviroment varaibles are required to run the test setup and the te
 - `IMAGE_REGISTRY_USERNAME` - quay.io username
 - `IMAGE_REGISTRY_PASSWORD` - quay.io password
 - `S3_BUCKET` - Name of S3 bucket that has the model
-- `TARGET_IMAGE_NAMESPACE` - Image registry namespace that the built model will be pushed to a repository in (the repository name will be the same as the model name).
+- `TARGET_IMAGE_TAGS_JSON` - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
 - `NAMESPACE` - Cluster namespace used for testing
 
 ## Run tests locally

--- a/test/e2e-tests/support/options.go
+++ b/test/e2e-tests/support/options.go
@@ -8,7 +8,7 @@ import (
 const (
 	S3BucketNameEnvKey         = "S3_BUCKET"
 	TargetImageNamespaceEnvKey = "TARGET_IMAGE_NAMESPACE"
-	CLusterNamespaceEnvKey     = "NAMESPACE"
+	ClusterNamespaceEnvKey     = "NAMESPACE"
 )
 
 var (
@@ -49,8 +49,8 @@ func setOptions() (*Options, error) {
 		return options, fmt.Errorf("env variable %v not set, but is required to run tests", TargetImageNamespaceEnvKey)
 	}
 
-	if options.ClusterNamespace = os.Getenv(CLusterNamespaceEnvKey); options.ClusterNamespace == "" {
-		return options, fmt.Errorf("env variable %v not set, but is required to run tests", CLusterNamespaceEnvKey)
+	if options.ClusterNamespace = os.Getenv(ClusterNamespaceEnvKey); options.ClusterNamespace == "" {
+		return options, fmt.Errorf("env variable %v not set, but is required to run tests", ClusterNamespaceEnvKey)
 	}
 
 	return options, nil

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -103,7 +103,7 @@ func Test_PipelineRunsComplete(t *testing.T) {
 
 		// setting these values to the options passed in as env vars
 		support.SetPipelineRunParam("s3-bucket-name", support.NewStringParamValue(options.S3BucketName), &pipelineRun)
-		support.SetPipelineRunParam("target-imagerepo", support.NewStringParamValue(options.RegistryRepoName), &pipelineRun)
+		support.SetPipelineRunParam("target-image-tag-references", support.NewArrayParamValue(options.TargetImageTagReferences), &pipelineRun)
 
 		_, err = clients.PipelineRun.Create(ctx, &pipelineRun, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-2758

## Description
Before this change, the image registry, image name, and image tag, were all hardcoded or generated by the pipeline, rather than customizable through parameters.

This change makes it possible to specify one or more targets as full image tag references.

Accepting more than just a single image tag target allows for both uniqueness and meaning. The simplest example scenario is where there's a primary tag that's unique, which has the model version and pipelinerun id; then a secondary tag with just the model version, which tracks the current blessed image for that model version. Quay (and possibly other registries) even has a UI feature for visualising that different tags actually point to the same manifest.

It's still possible to use other parameters to generate a name just like before, as demonstrated in the example PipelineRun files.

## How has this been tested
- Pipelines run manually, using both example PipelineRuns
- `make go-test` passes
- Verified that this works with the following image registries:
  - [x] quay.io
  - [x] docker.io
  - [x] internal registry in OpenShift cluster

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
