### PR TITLE
RHOAIENG-3368|RHOAIENG-3461- Include Git model repo revision param and use it in the PR check

### DIFF
--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -12,12 +12,14 @@ spec:
     value: "1"
   - name: s3-bucket-name
     value: rhoai-edge-models
-  - name: gitServer
+  - name: containerfileGitServer
     value: https://github.com
-  - name: gitOrgName
+  - name: containerfileGitOrgName
     value: opendatahub-io
-  - name: gitRepoName
+  - name: containerfileGitRepoName
     value: ai-edge
+  - name: containerfileGitRevision
+    value: "main"
   - name: containerfileRelativePath
     value: pipelines/containerfiles/Containerfile.seldonio.mlserver.mlflow
   - name: fetch-model
@@ -26,7 +28,7 @@ spec:
     value: https://github.com/opendatahub-io/ai-edge.git
   - name: modelRelativePath
     value: ""
-  - name: git-revision
+  - name: git-model-revision
     value: "main"
   - name: test-endpoint
     value: "invocations"

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -12,13 +12,9 @@ spec:
     value: "1"
   - name: s3-bucket-name
     value: rhoai-edge-models
-  - name: containerfileGitServer
-    value: https://github.com
-  - name: containerfileGitOrgName
-    value: opendatahub-io
-  - name: containerfileGitRepoName
-    value: ai-edge
-  - name: containerfileGitRevision
+  - name: git-containerfile-repo
+    value: https://github.com/opendatahub-io/ai-edge.git
+  - name: git-containerfile-revision
     value: "main"
   - name: containerfileRelativePath
     value: pipelines/containerfiles/Containerfile.seldonio.mlserver.mlflow

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -15,16 +15,10 @@ spec:
     type: string
     description: "[S3 ONLY] S3 bucket name where the model is stored"
     default: ""
-  - name: containerfileGitServer
+  - name: git-containerfile-repo
     type: string
-    description: Root domain of the Git server where the Containerfile repository is located
-  - name: containerfileGitOrgName
-    type: string
-    description: Organization or Group name where the Containerfile repository is located
-  - name: containerfileGitRepoName
-    type: string
-    description: Name of the Git repository with the Containerfile
-  - name: containerfileGitRevision
+    description: Git repository where the Containerfile is stored
+  - name: git-containerfile-revision
     type: string
     description: Git revision to checkout when cloning the repository with the Containerfile
     default: "main"
@@ -163,9 +157,9 @@ spec:
   - name: git-clone-containerfile-repo
     params:
     - name: url
-      value: $(params.containerfileGitServer)/$(params.containerfileGitOrgName)/$(params.containerfileGitRepoName)
+      value: $(params.git-containerfile-repo)
     - name: revision
-      value: $(params.containerfileGitRevision)
+      value: $(params.git-containerfile-revision)
     - name: subdirectory
       value: /containerfile_repo/
     runAfter:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -15,15 +15,19 @@ spec:
     type: string
     description: "[S3 ONLY] S3 bucket name where the model is stored"
     default: ""
-  - name: gitServer
+  - name: containerfileGitServer
     type: string
-    description: Root domain of the Git server
-  - name: gitOrgName
+    description: Root domain of the Git server where the Containerfile repository is located
+  - name: containerfileGitOrgName
     type: string
-    description: Organization or Group name where the repo is located
-  - name: gitRepoName
+    description: Organization or Group name where the Containerfile repository is located
+  - name: containerfileGitRepoName
     type: string
-    description: Git repository name
+    description: Name of the Git repository with the Containerfile
+  - name: containerfileGitRevision
+    type: string
+    description: Git revision to checkout when cloning the repository with the Containerfile
+    default: "main"
   - name: containerfileRelativePath
     type: string
     description: Path to the Containerfile in the git repository for model server imagebuild
@@ -41,7 +45,7 @@ spec:
     type: string
     description: The git repo url where the model files are stored
     default: ""
-  - name: git-revision
+  - name: git-model-revision
     type: string
     description: The Git ref to use when cloning the git repo with the saved model
     default: "main"
@@ -125,7 +129,7 @@ spec:
     - name: url
       value: $(params.git-model-repo)
     - name: revision
-      value: $(params.git-revision)
+      value: $(params.git-model-revision)
     - name: subdirectory
       value: /model_dir-$(params.model-name)/
     workspaces:
@@ -159,7 +163,9 @@ spec:
   - name: git-clone-containerfile-repo
     params:
     - name: url
-      value: $(params.gitServer)/$(params.gitOrgName)/$(params.gitRepoName)
+      value: $(params.containerfileGitServer)/$(params.containerfileGitOrgName)/$(params.containerfileGitRepoName)
+    - name: revision
+      value: $(params.containerfileGitRevision)
     - name: subdirectory
       value: /containerfile_repo/
     runAfter:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
@@ -12,13 +12,9 @@ spec:
     value: "1"
   - name: s3-bucket-name
     value: rhoai-edge-models
-  - name: containerfileGitServer
-    value: https://github.com
-  - name: containerfileGitOrgName
-    value: opendatahub-io
-  - name: containerfileGitRepoName
-    value: ai-edge
-  - name: containerfileGitRevision
+  - name: git-containerfile-repo
+    value: https://github.com/opendatahub-io/ai-edge.git
+  - name: git-containerfile-revision
     value: "main"
   - name: containerfileRelativePath
     value: pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
@@ -12,12 +12,14 @@ spec:
     value: "1"
   - name: s3-bucket-name
     value: rhoai-edge-models
-  - name: gitServer
+  - name: containerfileGitServer
     value: https://github.com
-  - name: gitOrgName
+  - name: containerfileGitOrgName
     value: opendatahub-io
-  - name: gitRepoName
+  - name: containerfileGitRepoName
     value: ai-edge
+  - name: containerfileGitRevision
+    value: "main"
   - name: containerfileRelativePath
     value: pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow
   - name: fetch-model
@@ -28,7 +30,7 @@ spec:
     value: pipelines/models
   - name: model-dir
     value: "tf2model"
-  - name: git-revision
+  - name: git-model-revision
     value: "main"
   - name: test-endpoint
     value: "v1/models/tensorflow-housing/versions/1:predict"

--- a/test/shell-pipeline-tests/README.md
+++ b/test/shell-pipeline-tests/README.md
@@ -33,3 +33,7 @@ ARTIFACT_DIR=./artifacts CUSTOM_AWS_SECRET_PATH=./secrets CUSTOM_IMAGE_REGISTRY_
 ```
 
 This would put all the logs into the `$PWD/artifacts` directory and it also expects all the credential files to be stored under the `$PWD/secrets` directory.
+
+> [!NOTE]
+> If you have made changes to Containerfiles or models used in the tests, change the Pipeline Run parameters accordingly, i.e. to fetch these files from your branch.
+> This is done automatically if running in the OpenShift CI environment.

--- a/test/shell-pipeline-tests/common.sh
+++ b/test/shell-pipeline-tests/common.sh
@@ -74,3 +74,11 @@ function createImageRegistrySecret() {
     sed -i "s|{{ IMAGE_REGISTRY_USERNAME }}|${USERNAME}|" "$IMAGE_REGISTRY_SECRET_PATH"
     sed -i "s|{{ IMAGE_REGISTRY_PASSWORD }}|${PASSWORD}|" "$IMAGE_REGISTRY_SECRET_PATH"
 }
+
+function usePRBranchInPipelineRunIfPRCheck() {
+  local -r PIPELINE_RUN_FILE_PATH=$1
+
+  if [ -n $PULL_NUMBER ]; then
+    sed -i "s|value: \"main\"|value: \"pull/$PULL_NUMBER/head\"|" "$PIPELINE_RUN_FILE_PATH"
+  fi
+}

--- a/test/shell-pipeline-tests/openvino-tensorflow-housing/pipelines-test-openvino-tensorflow-housing.sh
+++ b/test/shell-pipeline-tests/openvino-tensorflow-housing/pipelines-test-openvino-tensorflow-housing.sh
@@ -37,6 +37,7 @@ oc apply -k "$AIEDGE_E2E_PIPELINE_DIR_PATH"/
 AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.pipelinerun-overridden.yaml
 cp "$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.tensorflow-housing.pipelinerun.yaml "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 sed -i "s|value: \"delete\"|value: \"keep\"|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+usePRBranchInPipelineRunIfPRCheck "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 
 ## oc create pipeline run
 oc create -f "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"

--- a/test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh
+++ b/test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh
@@ -38,6 +38,7 @@ AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH="$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.p
 cp "$AIEDGE_E2E_PIPELINE_DIR_PATH"/aiedge-e2e.bike-rentals.pipelinerun.yaml "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 sed -i "s|value: rhoai-edge-models|value: rhoai-edge-models-ci|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 sed -i "s|value: \"delete\"|value: \"keep\"|" "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
+usePRBranchInPipelineRunIfPRCheck "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"
 
 ## oc create pipeline run
 oc create -f "$AIEDGE_E2E_PIPELINE_OVERRIDDEN_PATH"


### PR DESCRIPTION
**JIRAs:**
* [RHOAIENG-3368](https://issues.redhat.com/browse/RHOAIENG-3368)
* [RHOAIENG-3461](https://issues.redhat.com/browse/RHOAIENG-3461)

## Description
This PR fixes 2 issues:
* Adds a parameter to be able to configure a Git revision to checkout when fetching the model from the Git repository.
* Sets this parameter to the [pull request ref](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally?platform=linux#modifying-an-inactive-pull-request-locally) when the PR check in OpenShift CI is run to ensure the latest changes are tested.

## How Has This Been Tested?
Locally on an OpenShift cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
