### PR TITLE
RHOAIENG-2758: Remove need to explicitly create imagestream

### DIFF
--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -188,18 +188,6 @@ spec:
     workspaces:
     - name: workspace
       workspace: build-workspace-pv
-  - name: create-imagestream
-    params:
-    - name: SCRIPT
-      value: oc create imagestream $(params.model-name)  --lookup-local=true --dry-run=client
-        -o yaml | oc apply -f -
-    - name: VERSION
-      value: latest
-    runAfter:
-    - check-model-and-containerfile-exists
-    taskRef:
-      kind: ClusterTask
-      name: openshift-client
   - name: build-container
     params:
     - name: IMAGE
@@ -221,7 +209,7 @@ spec:
     - name: SKIP_PUSH
       value: "false"
     runAfter:
-    - create-imagestream
+    - check-model-and-containerfile-exists
     taskRef:
       kind: ClusterTask
       name: buildah
@@ -254,7 +242,7 @@ spec:
                 app: $(params.model-name)-$(params.model-version)
             spec:
               containers:
-              - image: $(params.model-name):$(params.model-version)
+              - image: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)
                 name: $(params.model-name)-$(params.model-version)
                 livenessProbe:
                   failureThreshold: 10


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-2758

This is a preparatory change for RHOAIENG-2758, where we want to be able to use different image registries for the candidate image that the pipeline builds.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before this change, we were explicitly creating the imagestream for the candidate image from the build task, just so that we could set the value of `spec.lookupPolicy.local` to `true`. While we could have left the imagestream to be implicitly created with default config just by pushing an image with the equivalent name, this value would not have had the desired value.

When the value of `spec.lookupPolicy.local` is at the default of false, then referring to an image by just `<name>:<tag>` without fully qualifying it with the registry domain, then it would default to the `docker.io` registry, and ignore the repository with that name in the internal registry in the cluster.

By setting the container image path to the fully qualified name, including the registry part (the same has how we specify it with in the parameter to the buildah task), then we don't need to care about the `spec.lookupPolicy.local` field, and can rely on the default creation of the ImageStream.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Pipeline has been run in a new namespace, where the ImageStream didn't exist.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
