### PR TITLE
RHOAIENG-437: Add instructions to fetch models from different s3 regions

### DIFF
--- a/pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template
+++ b/pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template
@@ -7,5 +7,9 @@ metadata:
     app.kubernetes.io/part-of: rhoai-edge-pipelines
 
 stringData:
+  # The endpoint_url property is an optional one when using AWS S3, you can ignore it totally in case of AWS S3.
+  # Generally it takes priority over the region when specified. 
+  # If the endpoint_url is not specified it would default to an AWS endpoint based on region specified.
+  # Set the bucket region correctly.
   s3-storage-config: |+
     { "type": "s3", "access_key_id": "{{ AWS_ACCESS_KEY_ID }}", "secret_access_key": "{{ AWS_SECRET_ACCESS_KEY }}", "endpoint_url": "{{ S3_ENDPOINT }}", "region": "{{ S3_REGION }}" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds instructions to the [credentials-s3.secret.template](https://github.com/opendatahub-io/ai-edge/blob/5960d4fc90c6f5aeb7c6a4eab5af5b1c2e972158/pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template) about the optional endpoint_url and region params. [JIRA](https://issues.redhat.com/browse/RHOAIENG-437)

To fetch models from S3 in a different region from the IAM credentials, user can consider endpoint_url param as an optional one and pass the correct region to the credentials secret. This way region will take precedence over endpoint_url and allows the task to download model from the specified region.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
