### PR TITLE
RHOAIENG-1119: Don't rely on imagestream in image info task

### DIFF
--- a/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
@@ -21,7 +21,7 @@ spec:
   - name: images-url
   steps:
   - name: get-image-sha
-    image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+    image: registry.access.redhat.com/ubi9/skopeo
     args:
       - "$(params.target-image-tag-references[*])"
     script: |
@@ -33,18 +33,18 @@ spec:
       echo ;
       echo -n "$(params.model-version)" | tee $(results.model-version.path) ;
       echo ;
-      export DOCKER_IMAGE_REF=$(oc get -n $(params.namespace) -o jsonpath='{.image.dockerImageReference}' imagestreamtag/$(params.model-name):$(params.model-version)) ;
+      export DOCKER_IMAGE_REF=$(skopeo inspect --format '{{.Name}}@{{.Digest}}' docker://image-registry.openshift-image-registry.svc:5000/$(params.namespace)/$(params.model-name):$(params.model-version)) ;
       if [[ $DOCKER_IMAGE_REF != *"$(params.buildah-sha)"* ]]; then
-        echo "ImageStreamTag doesn't contain the correct image SHA"
+        echo "Candidate image tag does not contain the correct manifest digest after push"
         exit 1 ;
       fi
       echo -n $DOCKER_IMAGE_REF | tee $(results.internal-image-url.path) ;
       echo ;
-      oc get -n $(params.namespace) -o jsonpath='{.image.dockerImageMetadata.Size}' imagestreamtag/$(params.model-name):$(params.model-version) | tee $(results.internal-image-size.path) ;
+      echo $(($(skopeo inspect --format '{{range .LayersData}}+{{.Size}}{{end}}' docker://$DOCKER_IMAGE_REF))) | tee $(results.internal-image-size.path) ;
       echo ;
-      oc get -n $(params.namespace) -o jsonpath='{.image.dockerImageMetadata.Created}' imagestreamtag/$(params.model-name):$(params.model-version) | tee $(results.internal-image-created-at.path) ;
+      skopeo inspect --format '{{.Created}}' docker://$DOCKER_IMAGE_REF | tee $(results.internal-image-created-at.path) ;
       echo ;
-      oc get -n $(params.namespace) -o jsonpath='{.image.dockerImageMetadata.Config.Labels.io\.buildah\.version}' imagestreamtag/$(params.model-name):$(params.model-version) | tee $(results.internal-image-buildah-version.path) ;
+      skopeo inspect --format '{{index .Labels "io.buildah.version"}}' docker://$DOCKER_IMAGE_REF | tee $(results.internal-image-buildah-version.path) ;
       echo ;
       echo -n "$@" | tee $(results.target-image-tag-references.path) ;
   - name: build-urls-txt


### PR DESCRIPTION
This PR stacks upon #215 as another preparatory commit for [RHOAIENG-1119](https://issues.redhat.com//browse/RHOAIENG-1119). It will be held until that one is merged, but it can still be reviewed, by just reviewing the new commit(s).

## Description
With this change, we now get info for the image from the image metadata using `skopeo inspect`, rather than from the ImageStream resource in OpenShift.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `make go-test` runs successfully
- Example pipelineruns executed manually with success

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
