### PR TITLE
RHOAIENG-1119: Add new candidate-image-tag-reference parameter

### DIFF
--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -30,6 +30,8 @@ spec:
     value: "main"
   - name: test-endpoint
     value: "invocations"
+  - name: candidate-image-tag-reference
+    value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)-candidate
   - name: target-image-tag-references
     value:
     - quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -51,6 +51,10 @@ spec:
   - default: $(context.pipelineRun.namespace)
     name: target-namespace
     type: string
+  - name: candidate-image-tag-reference
+    type: string
+    description: "A fully qualified image tag reference to be used for the candidate image build. E.g. registry.example.com/my-org/ai-model:1.0-1-candidate"
+    default: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)-candidate
   - name: target-image-tag-references
     type: array
     description: "An array of fully qualified image tag references to be used for the final image push. E.g. registry.example.com/my-org/ai-model:1.0-1"
@@ -191,7 +195,7 @@ spec:
   - name: build-container
     params:
     - name: IMAGE
-      value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)
+      value: $(params.candidate-image-tag-reference)
     - name: BUILDER_IMAGE
       value: registry.redhat.io/ubi9/buildah:latest
     - name: STORAGE_DRIVER
@@ -242,7 +246,7 @@ spec:
                 app: $(params.model-name)-$(params.model-version)
             spec:
               containers:
-              - image: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)
+              - image: $(params.candidate-image-tag-reference)
                 name: $(params.model-name)-$(params.model-version)
                 livenessProbe:
                   failureThreshold: 10
@@ -337,6 +341,8 @@ spec:
       value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: pipeline-run-uid
       value: $(context.pipelineRun.uid)
+    - name: candidate-image-tag-reference
+      value: $(params.candidate-image-tag-reference)
     - name: target-image-tag-references
       value: ["$(params.target-image-tag-references[*])"]
     runAfter:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml
@@ -32,6 +32,8 @@ spec:
     value: "main"
   - name: test-endpoint
     value: "v1/models/tensorflow-housing/versions/1:predict"
+  - name: candidate-image-tag-reference
+    value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.model-name):$(params.model-version)-candidate
   - name: target-image-tag-references
     value:
     - quay.io/rhoai-edge/$(params.model-name):$(params.model-version)-$(context.pipelineRun.uid)

--- a/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
@@ -15,6 +15,8 @@ spec:
     type: string
   - name: pipeline-run-uid
     type: string
+  - name: candidate-image-tag-reference
+    type: string
   - name: target-image-tag-references
     type: array
   workspaces:
@@ -33,7 +35,7 @@ spec:
       echo ;
       echo -n "$(params.model-version)" | tee $(results.model-version.path) ;
       echo ;
-      export DOCKER_IMAGE_REF=$(skopeo inspect --format '{{.Name}}@{{.Digest}}' docker://image-registry.openshift-image-registry.svc:5000/$(params.namespace)/$(params.model-name):$(params.model-version)) ;
+      export DOCKER_IMAGE_REF=$(skopeo inspect --format '{{.Name}}@{{.Digest}}' docker://$(params.candidate-image-tag-reference)) ;
       if [[ $DOCKER_IMAGE_REF != *"$(params.buildah-sha)"* ]]; then
         echo "Candidate image tag does not contain the correct manifest digest after push"
         exit 1 ;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR stacks upon #215 and #217. It will be held until those are merged, but it can still be reviewed, by just reviewing the new commit(s). This PR is the main change for the [RHOAIENG-1119](https://issues.redhat.com//browse/RHOAIENG-1119).

## Description
This will allow overriding the internal image registry reference, and
use any other image registry, repo, and tag instead.

There's a default set for the new param to maintain the old behaviour,
and the same value is set in the example PipelineRun files by default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `make go-test` run successfully
- Example pipelines run manually using default value for new parameter, proving that existing behaviour works as expected.
- Example pipelines run, with the new parameter set to `quay.io/grdryn/$(params.model-name):$(params.model-version)-candidate`, proving that an external registry can easily be used for the candidate image, as can be seen in the following screenshot (see tag `1-candidate`):
![image](https://github.com/opendatahub-io/ai-edge/assets/442386/d55e6993-58c5-4511-bbb1-d4a5e8d16b9d)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
