### PR TITLE
RHOAIENG-1119: Update result names that assume "internal" image

### DIFF
--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -90,18 +90,18 @@ spec:
   - name: model-files-list
     description: The list of model files
     value: $(tasks.check-model-and-containerfile-exists.results.model-files-list)
-  - name: internal-registry-url
-    description: The tag where the model container image was pushed to in the internal registry (e.g. image-reg...svc:5000/rhoai-models/ai-model:1-232)
+  - name: candidate-image-tag-reference
+    description: The tag where the candidate model container image was pushed to
     value: $(tasks.build-container.results.IMAGE_URL)
   - name: target-image-tag-references
     description: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)
     value: $(tasks.retrieve-build-image-info.results.target-image-tag-references)
-  - name: internal-image-url
-    description: The url of the image in the internal registry
-    value: $(tasks.retrieve-build-image-info.results.internal-image-url)
-  - name: internal-image-size
-    description: The size of the model container image in the internal registry in bytes
-    value: $(tasks.retrieve-build-image-info.results.internal-image-size)
+  - name: image-digest-reference
+    description: The fully qualified image digest reference of the image
+    value: $(tasks.retrieve-build-image-info.results.image-digest-reference)
+  - name: image-size-bytes
+    description: The size of the model container image in bytes
+    value: $(tasks.retrieve-build-image-info.results.image-size-bytes)
   - name: buildah-sha
     description: The SHA digest of the model container image
     value: $(tasks.build-container.results.IMAGE_DIGEST)
@@ -111,12 +111,12 @@ spec:
   - name: model-version
     description: The model version
     value: $(tasks.retrieve-build-image-info.results.model-version)
-  - name: internal-image-created-at
-    description: Timestamp of when the model container image was created in UTC format
-    value: $(tasks.retrieve-build-image-info.results.internal-image-created-at)
-  - name: internal-image-buildah-version
+  - name: image-creation-time
+    description: The date and time the image was created at
+    value: $(tasks.retrieve-build-image-info.results.image-creation-time)
+  - name: buildah-version
     description: The buildah version used to build the model container image
-    value: $(tasks.retrieve-build-image-info.results.internal-image-buildah-version)
+    value: $(tasks.retrieve-build-image-info.results.buildah-version)
   tasks:
   - name: fetch-model-git
     taskRef:

--- a/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/retrieve-build-image-info.task.yaml
@@ -40,13 +40,13 @@ spec:
         echo "Candidate image tag does not contain the correct manifest digest after push"
         exit 1 ;
       fi
-      echo -n $DOCKER_IMAGE_REF | tee $(results.internal-image-url.path) ;
+      echo -n $DOCKER_IMAGE_REF | tee $(results.image-digest-reference.path) ;
       echo ;
-      echo $(($(skopeo inspect --format '{{range .LayersData}}+{{.Size}}{{end}}' docker://$DOCKER_IMAGE_REF))) | tee $(results.internal-image-size.path) ;
+      echo $(($(skopeo inspect --format '{{range .LayersData}}+{{.Size}}{{end}}' docker://$DOCKER_IMAGE_REF))) | tee $(results.image-size-bytes.path) ;
       echo ;
-      skopeo inspect --format '{{.Created}}' docker://$DOCKER_IMAGE_REF | tee $(results.internal-image-created-at.path) ;
+      skopeo inspect --format '{{.Created}}' docker://$DOCKER_IMAGE_REF | tee $(results.image-creation-time.path) ;
       echo ;
-      skopeo inspect --format '{{index .Labels "io.buildah.version"}}' docker://$DOCKER_IMAGE_REF | tee $(results.internal-image-buildah-version.path) ;
+      skopeo inspect --format '{{index .Labels "io.buildah.version"}}' docker://$DOCKER_IMAGE_REF | tee $(results.buildah-version.path) ;
       echo ;
       echo -n "$@" | tee $(results.target-image-tag-references.path) ;
   - name: build-urls-txt
@@ -61,7 +61,7 @@ spec:
       # The skopeo-copy task looks for this file in its workspace if the source and destination parameters are
       # empty. This is what allows pushing to more than one tag from the single taskrun.
       export URLTXT=$(workspaces.images-url.path)/url.txt
-      export SOURCE_IMAGE_REF=$(cat $(results.internal-image-url.path))
+      export SOURCE_IMAGE_REF=$(cat $(results.image-digest-reference.path))
 
       rm -f ${URLTXT}
       for target in "$@"; do
@@ -75,13 +75,13 @@ spec:
     description: The name of the model
   - name: model-version
     description: The version of the model
-  - name: internal-image-size
-    description: The size of the image
-  - name: internal-image-created-at
-    description: The date and time the image was created in UTC format
-  - name: internal-image-buildah-version
+  - name: image-size-bytes
+    description: The size of the image in bytes
+  - name: image-creation-time
+    description: The date and time the image was created at
+  - name: buildah-version
     description: The version of buildah used to build the image
-  - name: internal-image-url
-    description: The url of the image in the internal registry
+  - name: image-digest-reference
+    description: The fully qualified image digest reference of the image
   - name: target-image-tag-references
     description: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
~This PR stacks upon #215, #217, and #218. It will be held until those are merged, but it can still be reviewed, by just reviewing the new commit(s).~ This PR is an cleanup change to keep the result names meaningful.

JIRA: https://issues.redhat.com/browse/RHOAIENG-1119

## Description
<!--- Describe your changes in detail -->
The following result name changes are included in this change; because
the image is not necessarily internal any longer, and/or the
properties are not specific to the candidate image:

- `internal-registry-url` -> `candidate-image-tag-reference`
- `internal-image-url` -> `image-digest-reference`
- `internal-image-size` -> `image-size-bytes`
- `internal-image-created-at` -> `image-creation-time`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Example PipelineRuns execute successfully

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
