### PR TITLE
RHOAIENG-3461 - Fix

### DIFF
--- a/test/shell-pipeline-tests/common.sh
+++ b/test/shell-pipeline-tests/common.sh
@@ -78,7 +78,7 @@ function createImageRegistrySecret() {
 function usePRBranchInPipelineRunIfPRCheck() {
   local -r PIPELINE_RUN_FILE_PATH=$1
 
-  if [ -n $PULL_NUMBER ]; then
+  if [ -n "$PULL_NUMBER" ]; then
     sed -i "s|value: \"main\"|value: \"pull/$PULL_NUMBER/head\"|" "$PIPELINE_RUN_FILE_PATH"
   fi
 }


### PR DESCRIPTION
Fix for #214.
<!--- Provide a general summary of your changes in the Title above -->
Forgot to include the quotes, my bad. Without them, there is only 1 argument (`-n`) and the condition is [always true](https://www.gnu.org/software/bash/manual/bash.html#index-test):
```
1 argument
    The expression is true if, and only if, the argument is not null.
```


## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
