### PR TITLE
Rework the Data for testing the model inferencing endpoint section to focus on the default example setups.

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -123,7 +123,7 @@ To verify that that model container is working successfully, the pipeline invoke
 The Task expects a workspace `test-data` with files `data.json`, the jsondata payload for your model, and `output.json`, the expected json output for that input payload.
 
 The example PipelineRun files ([OpenVino example](tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml),
-[Seldon example](tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml) demonstrate that approach, referencing the ConfigMap defined in
+[Seldon example](tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml)) demonstrate that approach, referencing the ConfigMap defined in
 [tensorflow-housing-test-data-cm.yaml](tekton/aiedge-e2e/test-data/tensorflow-housing-test-data-cm.yaml) and
 [bike-rentals-test-data-cm.yaml](tekton/aiedge-e2e/test-data/bike-rentals-test-data-cm.yaml), respectively.
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -119,38 +119,15 @@ Create a copy of the file(s) below to include the required credentials for acces
     ```
 
 ### Data for testing the model inferencing endpoint
-To verify that that model container is working successfully, we include a test-model-rest-svc task, that will send data to the model inferencing endpoint and verify that expected output is returned.
-You will need to create a ConfigMap with two files `data.json`, the jsondata payload for your model and `output.json`, the expected json output of your model
+To verify that that model container is working successfully, the pipeline invokes a Task `test-model-rest-svc` which will send data to a testing container with the model inferencing endpoint and verify that expected output is returned.
+The Task expects a workspace `test-data` with files `data.json`, the jsondata payload for your model, and `output.json`, the expected json output for that input payload.
 
-```yaml
-# Example ConfigMap
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: my-model-test-data
+The example PipelineRun files ([OpenVino example](tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml),
+[Seldon example](tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml) demonstrate that approach, referencing the ConfigMap defined in
+[tensorflow-housing-test-data-cm.yaml](tekton/aiedge-e2e/test-data/tensorflow-housing-test-data-cm.yaml) and
+[bike-rentals-test-data-cm.yaml](tekton/aiedge-e2e/test-data/bike-rentals-test-data-cm.yaml), respectively.
 
-data:
-  data.json: |+
-    {"dataframe_split": {"columns":[ "day", "mnth", "year", "season","holiday", "weekday", "workingday", "weathersit", "temp", "hum", "windspeed" ], "data":[[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]]}}
-
-  output.json: '{"predictions": [331]}'
-```
-
-Once the test data configmap is created, it can be included as the `test-data` workspace in your PipelineRun file ([OpenVino example](tekton/aiedge-e2e/aiedge-e2e.tensorflow-housing.pipelinerun.yaml), [Seldon example](tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml)).
-```yaml
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-spec:
-  ...
-  workspaces:
-  - configMap:
-      name: my-model-test-data
-    name: test-data
-```
-
-There are 2 prepared test data configmaps, which you can use:
-* [bike-rentals-test-data-cm.yaml](tekton/aiedge-e2e/test-data/bike-rentals-test-data-cm.yaml)
-* [tensorflow-housing-test-data-cm.yaml](tekton/aiedge-e2e/test-data/tensorflow-housing-test-data-cm.yaml)
+If using your models, you will want to adjust these accordingly.
 
 ### Deploy the Pipeline
 From the user's Data Science Projects namespace where the Pipeline will be running


### PR DESCRIPTION

## Description

Rework the Data for testing the model inferencing endpoint section to focus on the default example setups.

The original content has a very strong "You will need to create a ConfigMap ..." at the start and "prepared test data configmaps, which you can use" but when following the two example models (bike rentals and housing), nothing needs to be created or used explicitly -- `oc apply -k` takes care of everything. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Not tested.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
