### PR TITLE
Make the GitOps pipeline find the target registry URL again

### DIFF
--- a/pipelines/tekton/gitops-update-pipeline/gitops-update-pipeline.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/gitops-update-pipeline.yaml
@@ -29,7 +29,7 @@ spec:
       type: string
     - name: useMergedBuildTestPipeline
       type: string
-      default: "false"
+      default: "true"
   results:
     - name: target-registry-url
       description: The url of the target registry (e.g. quay.io/rhoai-models/ai-model/)

--- a/pipelines/tekton/gitops-update-pipeline/test-mlflow-retrieve-image-info-task.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/test-mlflow-retrieve-image-info-task.yaml
@@ -20,7 +20,7 @@ spec:
         PIPELINE_NAME=aiedge-e2e
       fi
       echo "Using $PIPELINE_NAME pipeline"
-      oc get -n $(params.namespace) pipelinerun --selector tekton.dev/pipeline=$PIPELINE_NAME --sort-by=.status.completionTime -o jsonpath='{range .items[?(@.spec.params[0].name == "model-name")]}{.spec.params[?(@.name == "model-name")].value} {.status.results[?(@.name == "buildah-sha")].value} {.status.results[?(@.name == "target-registry-url")].value}{"\n"}{end}' | awk -v model=$(params.model-name) '$1 == model && NF == 3 { print $2, $3 }' | tail -1 | tee /dev/stderr | while read sha registry ; do echo -n "$sha" > $(results.image-sha.path) ; echo -n "$registry" > $(results.target-registry-url.path) ; done ;
+      oc get -n $(params.namespace) pipelinerun --selector tekton.dev/pipeline=$PIPELINE_NAME --sort-by=.status.completionTime -o jsonpath='{range .items[?(@.spec.params[0].name == "model-name")]}{.spec.params[?(@.name == "model-name")].value} {.status.results[?(@.name == "buildah-sha")].value} {.status.results[?(@.name == "target-image-tag-references")].value}{"\n"}{end}' | awk -v model=$(params.model-name) '$1 == model && NF > 2 { print $2, gensub(":.*", "", "1", $3) }' | tail -1 | tee /dev/stderr | while read sha registry ; do echo -n "$sha" > $(results.image-sha.path) ; echo -n "$registry" > $(results.target-registry-url.path) ; done ;
       test -s $(results.image-sha.path) && test -s $(results.target-registry-url.path)
   results:
   - name: target-registry-url

--- a/pipelines/tekton/gitops-update-pipeline/test-mlflow-retrieve-image-info-task.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/test-mlflow-retrieve-image-info-task.yaml
@@ -15,13 +15,12 @@ spec:
   - name: get-image-sha
     image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     script: |
+      PIPELINE_NAME=test-mlflow-image
       if [[ "$(params.useMergedBuildTestPipeline)" == "true" ]]; then
-        echo "Using aiedge-e2e pipeline"
-        oc get -n $(params.namespace) pipelinerun --selector tekton.dev/pipeline=aiedge-e2e --sort-by=.status.completionTime -o jsonpath='{range .items[?(@.spec.params[0].name == "model-name")]}{.spec.params[?(@.name == "model-name")].value} {.status.results[?(@.name == "buildah-sha")].value} {.status.results[?(@.name == "target-registry-url")].value}{"\n"}{end}' | awk -v model=$(params.model-name) '$1 == model && NF == 3 { print $2, $3 }' | tail -1 | tee /dev/stderr | while read sha registry ; do echo -n "$sha" > $(results.image-sha.path) ; echo -n "$registry" > $(results.target-registry-url.path) ; done ;
-      else
-        echo "Using test-mlflow-image pipeline"
-        oc get -n $(params.namespace) pipelinerun --selector tekton.dev/pipeline=test-mlflow-image --sort-by=.status.completionTime -o jsonpath='{range .items[?(@.spec.params[0].name == "model-name")]}{.spec.params[?(@.name == "model-name")].value} {.status.results[?(@.name == "image-sha")].value} {.status.results[?(@.name == "target-registry-url")].value}{"\n"}{end}' | awk -v model=$(params.model-name) '$1 == model && NF == 3 { print $2, $3 }' | tail -1 | tee /dev/stderr | while read sha registry ; do echo -n "$sha" > $(results.image-sha.path) ; echo -n "$registry" > $(results.target-registry-url.path) ; done ;
+        PIPELINE_NAME=aiedge-e2e
       fi
+      echo "Using $PIPELINE_NAME pipeline"
+      oc get -n $(params.namespace) pipelinerun --selector tekton.dev/pipeline=$PIPELINE_NAME --sort-by=.status.completionTime -o jsonpath='{range .items[?(@.spec.params[0].name == "model-name")]}{.spec.params[?(@.name == "model-name")].value} {.status.results[?(@.name == "buildah-sha")].value} {.status.results[?(@.name == "target-registry-url")].value}{"\n"}{end}' | awk -v model=$(params.model-name) '$1 == model && NF == 3 { print $2, $3 }' | tail -1 | tee /dev/stderr | while read sha registry ; do echo -n "$sha" > $(results.image-sha.path) ; echo -n "$registry" > $(results.target-registry-url.path) ; done ;
       test -s $(results.image-sha.path) && test -s $(results.target-registry-url.path)
   results:
   - name: target-registry-url


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make the GitOps pipeline find the target registry URL again. This amends e3e731b7bc143e1bbaa3a8f3a5a58bf242631c38 and e1cfc6839c7ec44bd5f5e7e54c31cc8cd22276c5 and uses the `target-image-tag-references` to figure out the registry URL.

Also updating the `useMergedBuildTestPipeline` because that's what the repo seems to default to these days.

## How Has This Been Tested?
Manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
