### PR TITLE
RHOAIENG-4992 - Remove useMergedBuildTestPipeline parameter from gito…

### DIFF
--- a/pipelines/tekton/gitops-update-pipeline/gitops-update-pipeline.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/gitops-update-pipeline.yaml
@@ -27,9 +27,6 @@ spec:
     - name: gitTokenSecretKey
       default: token
       type: string
-    - name: useMergedBuildTestPipeline
-      type: string
-      default: "true"
   results:
     - name: target-registry-url
       description: The url of the target registry (e.g. quay.io/rhoai-models/ai-model/)
@@ -50,8 +47,6 @@ spec:
         value: $(context.pipelineRun.namespace)
       - name: model-name
         value: $(params.model-name)
-      - name: useMergedBuildTestPipeline
-        value: $(params.useMergedBuildTestPipeline)
     - name: git-clone
       params:
         - name: url

--- a/pipelines/tekton/gitops-update-pipeline/test-mlflow-retrieve-image-info-task.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/test-mlflow-retrieve-image-info-task.yaml
@@ -9,17 +9,12 @@ spec:
     type: string
   - name: model-name
     type: string
-  - name: useMergedBuildTestPipeline
-    type: string
   steps:
   - name: get-image-sha
     image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     script: |
-      PIPELINE_NAME=test-mlflow-image
-      if [[ "$(params.useMergedBuildTestPipeline)" == "true" ]]; then
-        PIPELINE_NAME=aiedge-e2e
-      fi
-      echo "Using $PIPELINE_NAME pipeline"
+      PIPELINE_NAME=aiedge-e2e
+      echo "Getting data from the latest $PIPELINE_NAME pipeline run"
       oc get -n $(params.namespace) pipelinerun --selector tekton.dev/pipeline=$PIPELINE_NAME --sort-by=.status.completionTime -o jsonpath='{range .items[?(@.spec.params[0].name == "model-name")]}{.spec.params[?(@.name == "model-name")].value} {.status.results[?(@.name == "buildah-sha")].value} {.status.results[?(@.name == "target-image-tag-references")].value}{"\n"}{end}' | awk -v model=$(params.model-name) '$1 == model && NF > 2 { print $2, gensub(":.*", "", "1", $3) }' | tail -1 | tee /dev/stderr | while read sha registry ; do echo -n "$sha" > $(results.image-sha.path) ; echo -n "$registry" > $(results.target-registry-url.path) ; done ;
       test -s $(results.image-sha.path) && test -s $(results.target-registry-url.path)
   results:


### PR DESCRIPTION
…ps pipeline

**JIRA:** [RHOAIENG-4492](https://issues.redhat.com/browse/RHOAIENG-4492)
<!--- Provide a general summary of your changes in the Title above -->

## Description
The parameter is not needed now as we no longer have separate build & test pipelines.

## How Has This Been Tested?
Testing by running the gitops-update-pipeline, the output of it is the testing PR https://github.com/MarianMacik/ai-edge/pull/2

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
