### PR TITLE
RHOAIENG-2787: Let ArgoCD create namespace, rather than using ACM Policy

### DIFF
--- a/acm/odh-edge/base/namespace.yaml
+++ b/acm/odh-edge/base/namespace.yaml
@@ -3,3 +3,9 @@ kind: Namespace
 metadata:
   # edit this to the namespace where the model is deployed
   name: model-to-edge
+  labels:
+    # If your OpenShift GitOps (or ArgoCD) is in a different namespace
+    # than openshift-gitops, then update this label value to match.
+    # More information:
+    # https://docs.openshift.com/gitops/1.11/argocd_instance/setting-up-argocd-instance.html
+    argocd.argoproj.io/managed-by: openshift-gitops

--- a/acm/registration/near-edge/base/near-edge.yaml
+++ b/acm/registration/near-edge/base/near-edge.yaml
@@ -1,31 +1,4 @@
 ---
-apiVersion: policy.open-cluster-management.io/v1
-kind: Policy
-metadata:
-  name: namespace-policy
-  namespace: openshift-gitops
-spec:
-  disabled: false
-  policy-templates:
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
-          name: ns-has-argo-label
-        spec:
-          object-templates:
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: v1
-                kind: Namespace
-                metadata:
-                  labels:
-                    argocd.argoproj.io/managed-by: openshift-gitops
-                  name: near-edge-acm-template
-          pruneObjectBehavior: DeleteIfCreated
-          severity: low
-          remediationAction: enforce
----
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
@@ -42,20 +15,6 @@ spec:
       operator: Exists
     - key: cluster.open-cluster-management.io/unavailable
       operator: Exists
----
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: placement-binding
-  namespace: openshift-gitops
-placementRef:
-  apiGroup: cluster.open-cluster-management.io
-  kind: Placement
-  name: near-edge-clusters
-subjects:
-  - apiGroup: policy.open-cluster-management.io
-    kind: Policy
-    name: ensure-namespace-exists
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
@@ -24,14 +24,6 @@ patches:
     group: argoproj.io
     version: v1alpha1
     kind: ApplicationSet
-- patch: |-
-    - op: replace
-      path: /spec/policy-templates/0/objectDefinition/metadata/name
-      value: bike-rental-app-ns-has-argo-label
-  target:
-    group: policy.open-cluster-management.io
-    version: v1
-    kind: Policy
 
 replacements:
 - source:
@@ -54,23 +46,3 @@ replacements:
       kind: PlacementBinding
     fieldPaths:
       - placementRef.name
-- source:
-    kind: Policy
-    group: policy.open-cluster-management.io
-    fieldPath: metadata.name
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: PlacementBinding
-    fieldPaths:
-      - subjects.0.name
-- source:
-    group: argoproj.io
-    kind: ApplicationSet
-    fieldPath: spec.template.spec.destination.namespace
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: Policy
-    fieldPaths:
-    - spec.policy-templates.0.objectDefinition.spec.object-templates.0.objectDefinition.metadata.name

--- a/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
@@ -24,14 +24,6 @@ patches:
     group: argoproj.io
     version: v1alpha1
     kind: ApplicationSet
-- patch: |-
-    - op: replace
-      path: /spec/policy-templates/0/objectDefinition/metadata/name
-      value: tensorflow-housing-app-ns-has-argo-label
-  target:
-    group: policy.open-cluster-management.io
-    version: v1
-    kind: Policy
 
 replacements:
 - source:
@@ -54,23 +46,3 @@ replacements:
       kind: PlacementBinding
     fieldPaths:
       - placementRef.name
-- source:
-    kind: Policy
-    group: policy.open-cluster-management.io
-    fieldPath: metadata.name
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: PlacementBinding
-    fieldPaths:
-      - subjects.0.name
-- source:
-    group: argoproj.io
-    kind: ApplicationSet
-    fieldPath: spec.template.spec.destination.namespace
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: Policy
-    fieldPaths:
-    - spec.policy-templates.0.objectDefinition.spec.object-templates.0.objectDefinition.metadata.name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-2787

This is a preparatory commit for [RHOAIENG-2787](https://issues.redhat.com//browse/RHOAIENG-2787), as not needing to use ACM Policy will make things a little easier for non-ACM cases.

## Description

This works as expected as long as the namespace is specified in the GitOps repo, and has the correct `argocd.argoproj.io/managed-by` label value.
We already had the namespace specified in the GitOps repo, but we didn't include the label.

More information on this label can be found here:
https://docs.openshift.com/gitops/1.11/argocd_instance/setting-up-argocd-instance.html

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Created both example applications through ACM successfully, and noticed that they were created as expected on the edge clusters
- Deleted both of the apps successfully on the ACM hub cluster, and noticed that all of the resources, including the namespaces, were deleted on the edge clusters.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
