### PR TITLE
RHOAIENG-4166: Add support for self signed certs in the MLOps pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ GOFLAGS=""
 #	S3_ENDPOINT			- Endpint of the bucket
 #	IMAGE_REGISTRY_USERNAME		- quay.io username
 #	IMAGE_REGISTRY_PASSWORD		- quay.io password
+#	SELF_SIGNED_CERT		- Self signed cert to be used in pipeline (optional)
 go-test-setup:
 ifndef AWS_SECRET_ACCESS_KEY
 	$(error AWS_SECRET_ACCESS_KEY is undefined)
@@ -67,14 +68,18 @@ endif
 ifndef IMAGE_REGISTRY_PASSWORD
 	$(error IMAGE_REGISTRY_PASSWORD is undefined)
 endif
+ifdef SELF_SIGNED_CERT
+	oc create configmap self-signed-cert --from-file=ca-bundle.crt=${SELF_SIGNED_CERT}
+endif
 	@sed -e "s#{{ AWS_SECRET_ACCESS_KEY }}#${AWS_SECRET_ACCESS_KEY}#g" -e "s#{{ AWS_ACCESS_KEY_ID }}#${AWS_ACCESS_KEY_ID}#g" -e "s#{{ S3_REGION }}#${S3_REGION}#g" -e "s#{{ S3_ENDPOINT }}#${S3_ENDPOINT}#g" pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template | oc create -f -
 	@sed -e "s#{{ IMAGE_REGISTRY_USERNAME }}#${IMAGE_REGISTRY_USERNAME}#g" -e "s#{{ IMAGE_REGISTRY_PASSWORD }}#${IMAGE_REGISTRY_PASSWORD}#g" pipelines/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template | oc create -f -
 	oc secret link pipeline credentials-image-registry
 
 # requires:
-#	S3_BUCKET		- Name of S3 bucket that has the model
-#	NAMESPACE		- Cluster namespace that tests are run in
+#	S3_BUCKET	- Name of S3 bucket that contains the models
+#	NAMESPACE	- Cluster namespace that tests are run in
 #	TARGET_IMAGE_TAGS_JSON	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
+#	SELF_SIGNED_CERT	- Self signed cert to be used in pipeline (optional)
 go-test:
 ifndef S3_BUCKET
 	$(error S3_BUCKET is undefined)
@@ -85,7 +90,7 @@ endif
 ifndef TARGET_IMAGE_TAGS_JSON
 	$(error TARGET_IMAGE_TAGS_JSON is undefined)
 endif
-	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} ${GO} test -timeout 30m)
+	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} SELF_SIGNED_CERT=${SELF_SIGNED_CERT} ${GO} test -timeout 30m)
 
 test:
 	@(./test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh)

--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,13 @@ GO=go
 GOFLAGS=""
 
 # requires:
-#	AWS_SECRET_ACCESS_KEY		- Secret from AWS
-#	AWS_ACCESS_KEY_ID		- Access key from AWS
-#	S3_REGION			- Region of the bucket used to store the model
-#	S3_ENDPOINT			- Endpint of the bucket
-#	IMAGE_REGISTRY_USERNAME		- quay.io username
-#	IMAGE_REGISTRY_PASSWORD		- quay.io password
-#	SELF_SIGNED_CERT		- Self signed cert to be used in pipeline (optional)
+#	AWS_SECRET_ACCESS_KEY   - Secret from AWS
+#	AWS_ACCESS_KEY_ID       - Access key from AWS
+#	S3_REGION               - Region of the bucket used to store the model
+#	S3_ENDPOINT             - Endpint of the bucket
+#	IMAGE_REGISTRY_USERNAME - quay.io username
+#	IMAGE_REGISTRY_PASSWORD - quay.io password
+#	SELF_SIGNED_CERT        -  Local path to the self  signed cert to be used in pipeline (optional)
 go-test-setup:
 ifndef AWS_SECRET_ACCESS_KEY
 	$(error AWS_SECRET_ACCESS_KEY is undefined)
@@ -76,10 +76,10 @@ endif
 	oc secret link pipeline credentials-image-registry
 
 # requires:
-#	S3_BUCKET	- Name of S3 bucket that contains the models
-#	NAMESPACE	- Cluster namespace that tests are run in
-#	TARGET_IMAGE_TAGS_JSON	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
-#	SELF_SIGNED_CERT	- Self signed cert to be used in pipeline (optional)
+#	S3_BUCKET               - Name of S3 bucket that contains the models
+#	NAMESPACE               - Cluster namespace that tests are run in
+#	TARGET_IMAGE_TAGS_JSON  - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
+#	SELF_SIGNED_CERT        - Local path to the self signed cert to be used in pipeline (optional)
 go-test:
 ifndef S3_BUCKET
 	$(error S3_BUCKET is undefined)

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -130,6 +130,8 @@ spec:
     workspaces:
     - name: output
       workspace: build-workspace-pv
+    - name: ssl-ca-directory
+      workspace: ssl-certs
     when:
     - input: "$(params.fetch-model)"
       operator: in
@@ -371,3 +373,5 @@ spec:
   - name: git-basic-auth
     optional: true
   - name: test-data
+  - name: ssl-certs
+    optional: true

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -176,6 +176,8 @@ spec:
       workspace: build-workspace-pv
     - name: basic-auth
       workspace: git-basic-auth
+    - name: ssl-ca-directory
+      workspace: ssl-certs
   - name: check-model-and-containerfile-exists
     params:
     - name: model-name

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -16,17 +16,33 @@ The following enviroment varaibles are required to run the test setup and the te
 - `S3_ENDPOINT` - Endpint of the bucket
 - `IMAGE_REGISTRY_USERNAME` - quay.io username
 - `IMAGE_REGISTRY_PASSWORD` - quay.io password
-- `S3_BUCKET` - Name of S3 bucket that has the model
-- `TARGET_IMAGE_TAGS_JSON` - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
-- `NAMESPACE` - Cluster namespace used for testing
+
+The following enviroment varaibles are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
+- `SELF_SIGNED_CERT` - Path self signed cert to be used in pipeline
+
+
+```bash
+make go-test-setup
+```
 
 ## Run tests locally
+
+The following enviroment varaibles are required to run the tests. If any of these are not set then the tests will not run. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
+
+- `S3_BUCKET`	- Name of S3 bucket that contains the models
+- `NAMESPACE`	- Cluster namespace that tests are run in
+- `TARGET_IMAGE_TAGS_JSON`	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
+
+The following enviroment varaibles are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
+- `SELF_SIGNED_CERT` - Path self signed cert to be used in pipeline
+- `GO` - Custom Go installation path that is not used in `PATH`
+
 ```bash
 make go-test
 ```
 Set the go binary used for testing that is in your `PATH`
 ```bash
-make GO=go1.19 go-test
+make go-test
 ```
 
 ## CI/CD with Github Actions

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -8,7 +8,7 @@ A local install of the Go compiler is needed to run the tests. Go version `1.21`
 - Log into the target cluster using `oc login`. This will update your default `kubeconfig` for the tests to use
 - Create a S3 bucket with the models in the root directory
 
-The following enviroment varaibles are required to run the test setup and the tests themselves. If any of these are not set then the tests will not run. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
+The following enviroment variables are required to run the test setup and the tests themselves. If any of these are not set then the tests will not run. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 
 - `AWS_SECRET_ACCESS_KEY` - Secret from AWS
 - `AWS_ACCESS_KEY_ID` - Access key from AWS
@@ -17,8 +17,9 @@ The following enviroment varaibles are required to run the test setup and the te
 - `IMAGE_REGISTRY_USERNAME` - quay.io username
 - `IMAGE_REGISTRY_PASSWORD` - quay.io password
 
-The following enviroment varaibles are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
-- `SELF_SIGNED_CERT` - Path self signed cert to be used in pipeline
+The following enviroment variables are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
+
+- `SELF_SIGNED_CERT` - A path on your local machine to a self signed cert to be used in pipeline
 
 
 ```bash
@@ -27,22 +28,23 @@ make go-test-setup
 
 ## Run tests locally
 
-The following enviroment varaibles are required to run the tests. If any of these are not set then the tests will not run. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
+The following enviroment variables are required to run the tests. If any of these are not set then the tests will not run. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 
 - `S3_BUCKET`	- Name of S3 bucket that contains the models
 - `NAMESPACE`	- Cluster namespace that tests are run in
 - `TARGET_IMAGE_TAGS_JSON`	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
 
-The following enviroment varaibles are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
-- `SELF_SIGNED_CERT` - Path self signed cert to be used in pipeline
-- `GO` - Custom Go installation path that is not used in `PATH`
+The following enviroment variables are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
+
+- `SELF_SIGNED_CERT` - A path on your local machine to a self signed cert to be used in pipeline
+- `GO` - Custom Go installation path that is not set in your `PATH`
 
 ```bash
 make go-test
 ```
 Set the go binary used for testing that is in your `PATH`
 ```bash
-make go-test
+make GO=go1.19 go-test
 ```
 
 ## CI/CD with Github Actions

--- a/test/e2e-tests/support/options.go
+++ b/test/e2e-tests/support/options.go
@@ -58,7 +58,7 @@ func setOptions() (*Options, error) {
 	}
 
 	if options.SelfSignedCert = os.Getenv(SelfSignedCertEnvKey); options.SelfSignedCert == "" {
-		fmt.Printf("optional env variable %v not set, set it to use self signed certs", SelfSignedCertEnvKey)
+		fmt.Printf("optional env variable %v not set, set it to use self signed certs\n", SelfSignedCertEnvKey)
 	}
 
 	return options, nil

--- a/test/e2e-tests/support/options.go
+++ b/test/e2e-tests/support/options.go
@@ -10,6 +10,7 @@ const (
 	S3BucketNameEnvKey     = "S3_BUCKET"
 	TargetImageTagsEnvKey  = "TARGET_IMAGE_TAGS_JSON"
 	ClusterNamespaceEnvKey = "NAMESPACE"
+	SelfSignedCertEnvKey   = "SELF_SIGNED_CERT"
 )
 
 var (
@@ -20,6 +21,7 @@ type Options struct {
 	S3BucketName             string   // required
 	ClusterNamespace         string   // required
 	TargetImageTagReferences []string // required
+	SelfSignedCert           string   // optional
 }
 
 func GetOptions() (*Options, error) {
@@ -53,6 +55,10 @@ func setOptions() (*Options, error) {
 
 	if options.ClusterNamespace = os.Getenv(ClusterNamespaceEnvKey); options.ClusterNamespace == "" {
 		return options, fmt.Errorf("env variable %v not set, but is required to run tests", ClusterNamespaceEnvKey)
+	}
+
+	if options.SelfSignedCert = os.Getenv(SelfSignedCertEnvKey); options.SelfSignedCert == "" {
+		fmt.Printf("optional env variable %v not set, set it to use self signed certs", SelfSignedCertEnvKey)
 	}
 
 	return options, nil

--- a/test/e2e-tests/support/tekton.go
+++ b/test/e2e-tests/support/tekton.go
@@ -2,9 +2,19 @@ package support
 
 import (
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"sigs.k8s.io/yaml"
 )
+
+func MountConfigMapAsWorkspaceToPipelineRun(configMapName string, workspaceName string, pipelineRun *pipelinev1.PipelineRun) {
+	pipelineRun.Spec.Workspaces = append(pipelineRun.Spec.Workspaces, pipelinev1.WorkspaceBinding{
+		Name: workspaceName,
+		ConfigMap: &v1.ConfigMapVolumeSource{
+			LocalObjectReference: v1.LocalObjectReference{Name: configMapName},
+		},
+	})
+}
 
 func SetPipelineRunParam(name string, value pipelinev1.ParamValue, pipelineRun *pipelinev1.PipelineRun) {
 	for index := range pipelineRun.Spec.Params {

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -101,6 +101,12 @@ func Test_PipelineRunsComplete(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 
+		// the value of self signed cert here is the path to the cert
+		// we just need to know if it is set to anything to add the config map
+		if options.SelfSignedCert != "" {
+			support.MountConfigMapAsWorkspaceToPipelineRun("self-signed-cert", "ssl-certs", &pipelineRun)
+		}
+
 		// setting these values to the options passed in as env vars
 		support.SetPipelineRunParam("s3-bucket-name", support.NewStringParamValue(options.S3BucketName), &pipelineRun)
 		support.SetPipelineRunParam("target-image-tag-references", support.NewArrayParamValue(options.TargetImageTagReferences), &pipelineRun)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
What this does:
- A self signed cert can be passed as a parameter to the MLops pipeline and can be used for use with private services throughout the pipeline, but for ones that only use git
- Documents the process and an optional step in the pipeline docs

## How Has This Been Tested?
- Use the e2e test provided in the repo
- Update the pipeline run to use a git repo that uses SSC (ping me for a repo and a cert to use!)
- Get access to that self signed cert and use it's path in the e2e tests as below
- Run 
```bash
make AWS_SECRET_ACCESS_KEY=... AWS_ACCESS_KEY_ID=... S3_REGION=... S3_ENDPOINT=... IMAGE_REGISTRY_USERNAME=...  IMAGE_REGISTRY_PASSWORD=... SELF_SIGNED_CERT=<PATH_TO_SSC> S3_BUCKET=... NAMESPACE=... TARGET_IMAGE_TAGS_JSON=... go-test-setup
```

- And then run 
```bash
make AWS_SECRET_ACCESS_KEY=... AWS_ACCESS_KEY_ID=... S3_REGION=... S3_ENDPOINT=... IMAGE_REGISTRY_USERNAME=...  IMAGE_REGISTRY_PASSWORD=... SELF_SIGNED_CERT=<PATH_TO_SSC> S3_BUCKET=... NAMESPACE=... TARGET_IMAGE_TAGS_JSON=... go-test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
