### PR TITLE
Remove orphaned Policy and PlacementBinding references

### DIFF
--- a/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/bike-rental-app/kustomization.yaml
@@ -36,13 +36,3 @@ replacements:
       kind: ApplicationSet
     fieldPaths:
       - spec.generators.0.clusterDecisionResource.labelSelector.matchLabels.cluster\.open-cluster-management\.io/placement
-- source:
-    kind: Placement
-    group: cluster.open-cluster-management.io
-    fieldPath: metadata.name
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: PlacementBinding
-    fieldPaths:
-      - placementRef.name

--- a/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/overlays/tensorflow-housing-app/kustomization.yaml
@@ -36,13 +36,3 @@ replacements:
       kind: ApplicationSet
     fieldPaths:
       - spec.generators.0.clusterDecisionResource.labelSelector.matchLabels.cluster\.open-cluster-management\.io/placement
-- source:
-    kind: Placement
-    group: cluster.open-cluster-management.io
-    fieldPath: metadata.name
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: PlacementBinding
-    fieldPaths:
-      - placementRef.name

--- a/acm/registration/near-edge/test/bike-rental-app/kustomization.yaml
+++ b/acm/registration/near-edge/test/bike-rental-app/kustomization.yaml
@@ -32,34 +32,6 @@ patches:
 - patch: |-
     - op: test
       path: /metadata/name
-      value: bike-rental-app-namespace-policy
-    - op: test
-      path: /spec/policy-templates/0/objectDefinition/metadata/name
-      value: bike-rental-app-ns-has-argo-label
-    - op: test
-      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
-      value: bike-rental-app
-  target:
-    group: policy.open-cluster-management.io
-    kind: Policy
-
-- patch: |-
-    - op: test
-      path: /metadata/name
-      value: bike-rental-app-placement-binding
-    - op: test
-      path: /placementRef/name
-      value: bike-rental-app-placement
-    - op: test
-      path: /subjects/0/name
-      value: bike-rental-app-namespace-policy
-  target:
-    group: policy.open-cluster-management.io
-    kind: PlacementBinding
-
-- patch: |-
-    - op: test
-      path: /metadata/name
       value: bike-rental-app-placement
   target:
     group: cluster.open-cluster-management.io

--- a/acm/registration/near-edge/test/tensorflow-housing-app/kustomization.yaml
+++ b/acm/registration/near-edge/test/tensorflow-housing-app/kustomization.yaml
@@ -32,34 +32,6 @@ patches:
 - patch: |-
     - op: test
       path: /metadata/name
-      value: tensorflow-housing-app-namespace-policy
-    - op: test
-      path: /spec/policy-templates/0/objectDefinition/metadata/name
-      value: tensorflow-housing-app-ns-has-argo-label
-    - op: test
-      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
-      value: tensorflow-housing-app
-  target:
-    group: policy.open-cluster-management.io
-    kind: Policy
-
-- patch: |-
-    - op: test
-      path: /metadata/name
-      value: tensorflow-housing-app-placement-binding
-    - op: test
-      path: /placementRef/name
-      value: tensorflow-housing-app-placement
-    - op: test
-      path: /subjects/0/name
-      value: tensorflow-housing-app-namespace-policy
-  target:
-    group: policy.open-cluster-management.io
-    kind: PlacementBinding
-
-- patch: |-
-    - op: test
-      path: /metadata/name
       value: tensorflow-housing-app-placement
   target:
     group: cluster.open-cluster-management.io


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Follow-up to the #229 which contained some unused references to `Policy` and `PlacementBinding`. Unfortunately kustomize doesn't fail for test patch operation if a resource doesn't exist as can be seen in kubernetes-sigs/kustomize/issues/4379.

## How Has This Been Tested?
Ran kustomize before and after, there was no difference in the output, which means the removed parts were not applied.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
