### PR TITLE
RHOAIENG-4873: Kserve self signed certs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,14 @@ GO=go
 GOFLAGS=""
 
 # requires:
-#	AWS_SECRET_ACCESS_KEY   - Secret from AWS
-#	AWS_ACCESS_KEY_ID       - Access key from AWS
-#	S3_REGION               - Region of the bucket used to store the model
-#	S3_ENDPOINT             - Endpint of the bucket
-#	IMAGE_REGISTRY_USERNAME - quay.io username
-#	IMAGE_REGISTRY_PASSWORD - quay.io password
-#	SELF_SIGNED_CERT        -  Local path to the self  signed cert to be used in pipeline (optional)
+#	AWS_SECRET_ACCESS_KEY		- Secret from AWS
+#	AWS_ACCESS_KEY_ID		- Access key from AWS
+#	S3_REGION			- Region of the bucket used to store the model
+#	S3_ENDPOINT			- Endpint of the bucket
+#	IMAGE_REGISTRY_USERNAME		- quay.io username
+#	IMAGE_REGISTRY_PASSWORD		- quay.io password
+#	GIT_SELF_SIGNED_CERT		- Self signed cert to be used in pipeline by git (optional)
+#	S3_SELF_SIGNED_CERT		- Self signed cert to be used in pipeline by kserve (optional)
 go-test-setup:
 ifndef AWS_SECRET_ACCESS_KEY
 	$(error AWS_SECRET_ACCESS_KEY is undefined)
@@ -60,18 +61,22 @@ endif
 ifndef IMAGE_REGISTRY_PASSWORD
 	$(error IMAGE_REGISTRY_PASSWORD is undefined)
 endif
-ifdef SELF_SIGNED_CERT
-	oc create configmap self-signed-cert --from-file=ca-bundle.crt=${SELF_SIGNED_CERT}
+ifdef GIT_SELF_SIGNED_CERT
+	oc create configmap git-self-signed-cert --from-file=ca-bundle.crt=${GIT_SELF_SIGNED_CERT}
+endif
+ifdef S3_SELF_SIGNED_CERT
+	oc create configmap s3-self-signed-cert --from-file=ca-bundle.crt=${S3_SELF_SIGNED_CERT}
 endif
 	@sed -e "s#{{ AWS_SECRET_ACCESS_KEY }}#${AWS_SECRET_ACCESS_KEY}#g" -e "s#{{ AWS_ACCESS_KEY_ID }}#${AWS_ACCESS_KEY_ID}#g" -e "s#{{ S3_REGION }}#${S3_REGION}#g" -e "s#{{ S3_ENDPOINT }}#${S3_ENDPOINT}#g" pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template | oc create -f -
 	@sed -e "s#{{ IMAGE_REGISTRY_USERNAME }}#${IMAGE_REGISTRY_USERNAME}#g" -e "s#{{ IMAGE_REGISTRY_PASSWORD }}#${IMAGE_REGISTRY_PASSWORD}#g" pipelines/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template | oc create -f -
 	oc secret link pipeline credentials-image-registry
 
 # requires:
-#	S3_BUCKET               - Name of S3 bucket that contains the models
-#	NAMESPACE               - Cluster namespace that tests are run in
-#	TARGET_IMAGE_TAGS_JSON  - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
-#	SELF_SIGNED_CERT        - Local path to the self signed cert to be used in pipeline (optional)
+#	S3_BUCKET	- Name of S3 bucket that contains the models
+#	NAMESPACE	- Cluster namespace that tests are run in
+#	TARGET_IMAGE_TAGS_JSON	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
+#	GIT_SELF_SIGNED_CERT	- Self signed cert to be used in pipeline by git (optional)
+#	S3_SELF_SIGNED_CERT	- Self signed cert to be used in pipeline when fetching models from S3 (optional)
 go-test:
 ifndef S3_BUCKET
 	$(error S3_BUCKET is undefined)
@@ -82,7 +87,7 @@ endif
 ifndef TARGET_IMAGE_TAGS_JSON
 	$(error TARGET_IMAGE_TAGS_JSON is undefined)
 endif
-	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} SELF_SIGNED_CERT=${SELF_SIGNED_CERT} ${GO} test -timeout 30m)
+	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} GIT_SELF_SIGNED_CERT=${GIT_SELF_SIGNED_CERT} S3_SELF_SIGNED_CERT=${S3_SELF_SIGNED_CERT} ${GO} test -timeout 30m)
 
 test:
 	@(./test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh)

--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,14 @@ GO=go
 GOFLAGS=""
 
 # requires:
-#	AWS_SECRET_ACCESS_KEY		- Secret from AWS
-#	AWS_ACCESS_KEY_ID		- Access key from AWS
-#	S3_REGION			- Region of the bucket used to store the model
-#	S3_ENDPOINT			- Endpint of the bucket
-#	IMAGE_REGISTRY_USERNAME		- quay.io username
-#	IMAGE_REGISTRY_PASSWORD		- quay.io password
-#	GIT_SELF_SIGNED_CERT		- Self signed cert to be used in pipeline by git (optional)
-#	S3_SELF_SIGNED_CERT		- Self signed cert to be used in pipeline by kserve (optional)
+#   AWS_SECRET_ACCESS_KEY       - Secret from AWS
+#   AWS_ACCESS_KEY_ID           - Access key from AWS
+#   S3_REGION                   - Region of the bucket used to store the model
+#   S3_ENDPOINT                 - Endpint of the bucket
+#   IMAGE_REGISTRY_USERNAME     - quay.io username
+#   IMAGE_REGISTRY_PASSWORD     - quay.io password
+#   GIT_SELF_SIGNED_CERT        - Self-signed cert to be used in pipeline by git (optional)
+#   S3_SELF_SIGNED_CERT         - Self-signed cert to be used in pipeline by the script that's used to download the model from S3-compatible object storage (optional)
 go-test-setup:
 ifndef AWS_SECRET_ACCESS_KEY
 	$(error AWS_SECRET_ACCESS_KEY is undefined)
@@ -72,11 +72,11 @@ endif
 	oc secret link pipeline credentials-image-registry
 
 # requires:
-#	S3_BUCKET	- Name of S3 bucket that contains the models
-#	NAMESPACE	- Cluster namespace that tests are run in
-#	TARGET_IMAGE_TAGS_JSON	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
-#	GIT_SELF_SIGNED_CERT	- Self signed cert to be used in pipeline by git (optional)
-#	S3_SELF_SIGNED_CERT	- Self signed cert to be used in pipeline when fetching models from S3 (optional)
+#   S3_BUCKET               - Name of S3 bucket that contains the models
+#   NAMESPACE               - Cluster namespace that tests are run in
+#   TARGET_IMAGE_TAGS_JSON  - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
+#   GIT_SELF_SIGNED_CERT    - Self-signed cert to be used in pipeline by git (optional)
+#   S3_SELF_SIGNED_CERT     - Self-signed cert to be used in pipeline by the script that's used to download the model from S3-compatible object storage (optional)
 go-test:
 ifndef S3_BUCKET
 	$(error S3_BUCKET is undefined)

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -131,7 +131,7 @@ spec:
     - name: output
       workspace: build-workspace-pv
     - name: ssl-ca-directory
-      workspace: git-ssl-certs
+      workspace: git-ssl-cert
     when:
     - input: "$(params.fetch-model)"
       operator: in
@@ -154,7 +154,7 @@ spec:
     - name: s3-secret
       workspace: s3-secret
     - name: ssl-ca-directory
-      workspace: s3-ssl-certs
+      workspace: s3-ssl-cert
     when:
     - input: "$(params.fetch-model)"
       operator: in
@@ -179,7 +179,7 @@ spec:
     - name: basic-auth
       workspace: git-basic-auth
     - name: ssl-ca-directory
-      workspace: git-ssl-certs
+      workspace: git-ssl-cert
   - name: check-model-and-containerfile-exists
     params:
     - name: model-name
@@ -378,7 +378,7 @@ spec:
   - name: git-basic-auth
     optional: true
   - name: test-data
-  - name: git-ssl-certs
+  - name: git-ssl-cert
     optional: true
-  - name: s3-ssl-certs
+  - name: s3-ssl-cert
     optional: true

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -131,7 +131,7 @@ spec:
     - name: output
       workspace: build-workspace-pv
     - name: ssl-ca-directory
-      workspace: ssl-certs
+      workspace: git-ssl-certs
     when:
     - input: "$(params.fetch-model)"
       operator: in
@@ -153,6 +153,8 @@ spec:
       workspace: build-workspace-pv
     - name: s3-secret
       workspace: s3-secret
+    - name: ssl-ca-directory
+      workspace: s3-ssl-certs
     when:
     - input: "$(params.fetch-model)"
       operator: in
@@ -177,7 +179,7 @@ spec:
     - name: basic-auth
       workspace: git-basic-auth
     - name: ssl-ca-directory
-      workspace: ssl-certs
+      workspace: git-ssl-certs
   - name: check-model-and-containerfile-exists
     params:
     - name: model-name
@@ -376,5 +378,7 @@ spec:
   - name: git-basic-auth
     optional: true
   - name: test-data
-  - name: ssl-certs
+  - name: git-ssl-certs
+    optional: true
+  - name: s3-ssl-certs
     optional: true

--- a/pipelines/tekton/aiedge-e2e/tasks/kserve-download-model.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/kserve-download-model.yaml
@@ -24,6 +24,11 @@ spec:
       export S3_URL="s3://$(params.s3-bucket-name)/$(params.model-name)"
       echo -n $S3_URL | tee $(results.s3-url.path) ;
 
+      if [ -n "$(workspaces.ssl-ca-directory.path)" ]; then
+        export CA_BUNDLE_CONFIGMAP_NAME=ssl-ca-directory
+        export AWS_CA_BUNDLE=$(workspaces.ssl-ca-directory.path)/ca-bundle.crt
+      fi
+      
       STORAGE_CONFIG="$(cat $(workspaces.s3-secret.path)/s3-storage-config)" /storage-initializer/scripts/initializer-entrypoint \
       $S3_URL \
       $(workspaces.workspace.path)/model_dir-$(params.model-name)/$(params.model-name)
@@ -32,3 +37,8 @@ spec:
     name: workspace
   - description: The S3 secret.
     name: s3-secret
+  - description: |
+      A workspace containing CA certificates, this will be used by kserve to
+      verify the peer with when fetching over HTTPS.
+    name: ssl-ca-directory
+    optional: true

--- a/pipelines/tekton/aiedge-e2e/tasks/kserve-download-model.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/kserve-download-model.yaml
@@ -38,7 +38,7 @@ spec:
   - description: The S3 secret.
     name: s3-secret
   - description: |
-      A workspace containing CA certificates, this will be used by kserve to
+      A workspace containing CA certificates, this will be used by the model download script to
       verify the peer with when fetching over HTTPS.
     name: ssl-ca-directory
     optional: true

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -19,10 +19,8 @@ The following enviroment variables are required to run the test setup and the te
 
 The following enviroment variables are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 
-- `SELF_SIGNED_CERT` - A path on your local machine to a self signed cert to be used in pipeline
-
-- `GIT_SELF_SIGNED_CERT` - Self signed cert to be used by git when cloning (optional)
-- `S3_SELF_SIGNED_CERT` - Self signed cert to be used for S3 when pulling models (optional)
+- `GIT_SELF_SIGNED_CERT` - Self-signed cert to be used by git when cloning
+- `S3_SELF_SIGNED_CERT` - Self-signed cert to be used for S3 when pulling models
 
 
 ```bash
@@ -39,11 +37,12 @@ The following enviroment variables are required to run the tests. If any of thes
 
 The following enviroment variables are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 
-- `GIT_SELF_SIGNED_CERT` - Self signed cert to be used by git when cloning (optional)
-- `S3_SELF_SIGNED_CERT` - Self signed cert to be used for S3 when pulling models (optional)
+- `GIT_SELF_SIGNED_CERT` - Self-signed cert to be used by git when cloning
+- `S3_SELF_SIGNED_CERT` - Self-signed cert to be used for S3 when pulling models
 - `GO` - Custom Go installation path that is not set in your `PATH`
 
 ```bash
+- `S3_SELF_SIGNED_CERT` - Self signed cert to be used for S3 when pulling models
 make go-test
 ```
 Set the go binary used for testing that is in your `PATH`

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -21,6 +21,9 @@ The following enviroment variables are optional. You may still need to set them 
 
 - `SELF_SIGNED_CERT` - A path on your local machine to a self signed cert to be used in pipeline
 
+- `GIT_SELF_SIGNED_CERT` - Self signed cert to be used by git when cloning (optional)
+- `S3_SELF_SIGNED_CERT` - Self signed cert to be used for S3 when pulling models (optional)
+
 
 ```bash
 make go-test-setup
@@ -36,7 +39,8 @@ The following enviroment variables are required to run the tests. If any of thes
 
 The following enviroment variables are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 
-- `SELF_SIGNED_CERT` - A path on your local machine to a self signed cert to be used in pipeline
+- `GIT_SELF_SIGNED_CERT` - Self signed cert to be used by git when cloning (optional)
+- `S3_SELF_SIGNED_CERT` - Self signed cert to be used for S3 when pulling models (optional)
 - `GO` - Custom Go installation path that is not set in your `PATH`
 
 ```bash

--- a/test/e2e-tests/support/options.go
+++ b/test/e2e-tests/support/options.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	S3BucketNameEnvKey     = "S3_BUCKET"
-	TargetImageTagsEnvKey  = "TARGET_IMAGE_TAGS_JSON"
-	ClusterNamespaceEnvKey = "NAMESPACE"
-	SelfSignedCertEnvKey   = "SELF_SIGNED_CERT"
+	S3BucketNameEnvKey      = "S3_BUCKET"
+	TargetImageTagsEnvKey   = "TARGET_IMAGE_TAGS_JSON"
+	ClusterNamespaceEnvKey  = "NAMESPACE"
+	GitSelfSignedCertEnvKey = "GIT_SELF_SIGNED_CERT"
+	S3SelfSignedCertEnvKey  = "S3_SELF_SIGNED_CERT"
 )
 
 var (
@@ -21,7 +22,8 @@ type Options struct {
 	S3BucketName             string   // required
 	ClusterNamespace         string   // required
 	TargetImageTagReferences []string // required
-	SelfSignedCert           string   // optional
+	GitSelfSignedCert        string   // optional
+	S3SelfSignedCert         string   // optional
 }
 
 func GetOptions() (*Options, error) {
@@ -57,8 +59,12 @@ func setOptions() (*Options, error) {
 		return options, fmt.Errorf("env variable %v not set, but is required to run tests", ClusterNamespaceEnvKey)
 	}
 
-	if options.SelfSignedCert = os.Getenv(SelfSignedCertEnvKey); options.SelfSignedCert == "" {
-		fmt.Printf("optional env variable %v not set, set it to use self signed certs\n", SelfSignedCertEnvKey)
+	if options.GitSelfSignedCert = os.Getenv(GitSelfSignedCertEnvKey); options.GitSelfSignedCert == "" {
+		fmt.Printf("\noptional env variable %v not set, set it to use self signed certs with git", GitSelfSignedCertEnvKey)
+	}
+
+	if options.S3SelfSignedCert = os.Getenv(S3SelfSignedCertEnvKey); options.S3SelfSignedCert == "" {
+		fmt.Printf("\noptional env variable %v not set, set it to use self signed certs with S3", S3SelfSignedCertEnvKey)
 	}
 
 	return options, nil

--- a/test/e2e-tests/support/options.go
+++ b/test/e2e-tests/support/options.go
@@ -60,11 +60,11 @@ func setOptions() (*Options, error) {
 	}
 
 	if options.GitSelfSignedCert = os.Getenv(GitSelfSignedCertEnvKey); options.GitSelfSignedCert == "" {
-		fmt.Printf("\noptional env variable %v not set, set it to use self signed certs with git", GitSelfSignedCertEnvKey)
+		fmt.Printf("\noptional env variable %v not set, set it to use self-signed certs with git", GitSelfSignedCertEnvKey)
 	}
 
 	if options.S3SelfSignedCert = os.Getenv(S3SelfSignedCertEnvKey); options.S3SelfSignedCert == "" {
-		fmt.Printf("\noptional env variable %v not set, set it to use self signed certs with S3", S3SelfSignedCertEnvKey)
+		fmt.Printf("\noptional env variable %v not set, set it to use self-signed certs with S3", S3SelfSignedCertEnvKey)
 	}
 
 	return options, nil

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -103,10 +103,10 @@ func Test_PipelineRunsComplete(t *testing.T) {
 
 		// if given a path to each cert then mount them to the pipeline run
 		if options.GitSelfSignedCert != "" {
-			support.MountConfigMapAsWorkspaceToPipelineRun("git-self-signed-cert", "git-ssl-certs", &pipelineRun)
+			support.MountConfigMapAsWorkspaceToPipelineRun("git-self-signed-cert", "git-ssl-cert", &pipelineRun)
 		}
 		if options.S3SelfSignedCert != "" {
-			support.MountConfigMapAsWorkspaceToPipelineRun("s3-self-signed-cert", "s3-ssl-certs", &pipelineRun)
+			support.MountConfigMapAsWorkspaceToPipelineRun("s3-self-signed-cert", "s3-ssl-cert", &pipelineRun)
 		}
 
 		// setting these values to the options passed in as env vars

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -101,10 +101,12 @@ func Test_PipelineRunsComplete(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 
-		// the value of self signed cert here is the path to the cert
-		// we just need to know if it is set to anything to add the config map
-		if options.SelfSignedCert != "" {
-			support.MountConfigMapAsWorkspaceToPipelineRun("self-signed-cert", "ssl-certs", &pipelineRun)
+		// if given a path to each cert then mount them to the pipeline run
+		if options.GitSelfSignedCert != "" {
+			support.MountConfigMapAsWorkspaceToPipelineRun("git-self-signed-cert", "git-ssl-certs", &pipelineRun)
+		}
+		if options.S3SelfSignedCert != "" {
+			support.MountConfigMapAsWorkspaceToPipelineRun("s3-self-signed-cert", "s3-ssl-certs", &pipelineRun)
 		}
 
 		// setting these values to the options passed in as env vars


### PR DESCRIPTION
## Description
Add support for using self signed certs with kserve to download models from an object store 

## How Has This Been Tested?
- Use the e2e test provided in the repo
- Setup e2e tests as normal
```bash
make AWS_SECRET_ACCESS_KEY=... AWS_ACCESS_KEY_ID=... S3_REGION=... S3_ENDPOINT=... IMAGE_REGISTRY_USERNAME=...  IMAGE_REGISTRY_PASSWORD=... S3_BUCKET=... NAMESPACE=... TARGET_IMAGE_TAGS_JSON=... go-test-setup
```
- Set the new env variable `S3_SELF_SIGNED_CERT` as the path to the cert

- And then run 
```bash
make AWS_SECRET_ACCESS_KEY=... AWS_ACCESS_KEY_ID=... S3_REGION=... S3_ENDPOINT=... IMAGE_REGISTRY_USERNAME=...  IMAGE_REGISTRY_PASSWORD=...  S3_BUCKET=... NAMESPACE=... TARGET_IMAGE_TAGS_JSON=... S3_SELF_SIGNED_CERT=... go-test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
