### PR TITLE
Don't use PR branch for rehearsals in the openshift/release repository

### DIFF
--- a/test/shell-pipeline-tests/common.sh
+++ b/test/shell-pipeline-tests/common.sh
@@ -78,7 +78,7 @@ function createImageRegistrySecret() {
 function usePRBranchInPipelineRunIfPRCheck() {
   local -r PIPELINE_RUN_FILE_PATH=$1
 
-  if [ -n "$PULL_NUMBER" ]; then
+  if [ -n "$PULL_NUMBER" ] && [ "$REPO_NAME" == "ai-edge" ]; then
     sed -i "s|value: \"main\"|value: \"pull/$PULL_NUMBER/head\"|" "$PIPELINE_RUN_FILE_PATH"
   fi
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I found out that rehearsals run on the openshift/release repository PR set the value of the  `PULL_NUMBER` env variable of the job to the PR in the openshift/release repository. This naturally leads to a rehearsal job run failing because the pipeline is trying to fetch container files from the PR for ai-edge repository, which does not exist with that `PULL_NUMBER` (the PR exists just in the openshift/release repository). Therefore, for rehearsals we should always fetch the default, e.g. the main branch of the ai-edge repository, so the same approach we already use for nightly jobs.

## How Has This Been Tested?
Locally.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
