### PR TITLE
Remove METRICS_PORT container arg from openvino Containerfile

### DIFF
--- a/pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow
+++ b/pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow
@@ -4,8 +4,6 @@ ARG MODEL_NAME
 ARG MODEL_DIR="."
 ARG GRPC_PORT=9090
 ARG REST_PORT=8080
-# OVMS metrics currently only served on REST port https://docs.openvino.ai/2023.0/ovms_docs_metrics.html#enable-metrics
-ARG METRICS_PORT
 
 ENV MODEL_NAME_ENV=$MODEL_NAME
 ENV GRPC_PORT_ENV=$GRPC_PORT


### PR DESCRIPTION
## Description
Removes the `METRICS_PORT` argument from the openvino containerfile since it is not referenced anywhere in the build process and the openvino [metrics endpoint is served on the rest api port](https://docs.openvino.ai/2022.3/ovms_docs_metrics.html#enable-metrics) 


## How Has This Been Tested?
You can build this locally with any model format supported by openvino:

```bash
$ aws s3 cp --recursive s3://rhoai-edge/example-models/fraud-detection/ /tmp/fraud-detection

$ podman build --build-arg MODEL_NAME=fraud-detection -f pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow --tag openvino-fraud-detection /tmp/fraud-detection/1/

$ podman run -d --rm -p 8080:8080 localhost/openvino-fraud-detection:latest

$ curl localhost:8080/metrics
# HELP ovms_requests_success Number of successful requests to a model or a DAG.             
# TYPE ovms_requests_success counter                                                                           
ovms_requests_success{api="KServe",interface="REST",method="ModelReady",name="fraud-detection"} 0
ovms_requests_success{api="KServe",interface="gRPC",method="ModelReady",name="fraud-detection"} 0
ovms_requests_success{api="KServe",interface="gRPC",method="ModelInfer",name="fraud-detection",version="1"} 0

```

## Merge criteria:
Model builds successfully locally and in the pipelines with metrics enabled

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
