### PR TITLE
RHOAIENG-2244: Add support for fetching models from S3 based on the modelRelativePath & Adds a universal OpenVino ContainerFile

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,6 +29,9 @@ This repo currently contains two examples:
 | **Model (Pipelines)** | `tensorflow-housing`     | `bike-rentals-auto-ml` |
 | **App (ACM)**         | `tensorflow-housing-app` | `bike-rental-app`      |
 
+
+*Additionally*, you can follow the [OpenShift AI tutorial - Fraud detection example](https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.8/html/openshift_ai_tutorial_-_fraud_detection_example/index) to execute the end to end workflow of training a model from scratch & building the [inferencing container](pipelines/containerfiles/Containerfile.openvino) to deliver to Edge environments.
+
 ### Clusters
 
 > **Note**

--- a/pipelines/containerfiles/Containerfile.openvino
+++ b/pipelines/containerfiles/Containerfile.openvino
@@ -1,0 +1,35 @@
+FROM quay.io/opendatahub/openvino_model_server:stable
+
+# Name of the model that will be used as the based directory of the model files AND passed to openvino executable
+ARG MODEL_NAME
+# Location of the model files within the build context directory
+# Structure is based on OpenVino expectations of <BUILD_CONTEXT>/<MODEL_DIR>/<MODEL_VERSION>
+# See https://docs.openvino.ai/2024/ovms_docs_models_repository.html 
+ARG MODEL_DIR="."
+ARG GRPC_PORT=9090
+ARG REST_PORT=8080
+
+ENV MODEL_NAME=$MODEL_NAME
+ENV GRPC_PORT=$GRPC_PORT
+ENV REST_PORT=$REST_PORT
+
+USER root
+
+# Create the root directory for all models stored in this container
+RUN mkdir /models && chown ovms:ovms /models
+
+# Create /models/MODEL_NAME directory to ensure that --model_name passed to OpenVino matches
+# the directory where we store the model and version
+COPY --chown=ovms:ovms $MODEL_DIR /models/$MODEL_NAME
+
+# Remove the TensorFlow fingerprint.pb file if found as it causes an error in OpenVino when multiple
+#   protobuf(.pb) files  are present in the model directory
+#   See https://www.tensorflow.org/guide/saved_model for info on the TensorFlow model
+# Set permissions so that the container can run locally OR on OpenShift
+RUN find /models -name fingerprint.pb -delete && chmod o+rwX /models/ && chgrp -R 0 /models
+
+EXPOSE $REST_PORT $GRPC_PORT
+
+USER ovms
+
+ENTRYPOINT /ovms/bin/ovms --model_path /models/$MODEL_NAME --model_name $MODEL_NAME --port $GRPC_PORT --rest_port $REST_PORT --shape auto --metrics_enable

--- a/pipelines/containerfiles/Containerfile.openvino
+++ b/pipelines/containerfiles/Containerfile.openvino
@@ -1,10 +1,12 @@
+# Inference container image to support models compatible with OpenVino Model Server
+# OpenVino Support model formats - https://docs.openvino.ai/2024/openvino-workflow/model-preparation.html
 FROM quay.io/opendatahub/openvino_model_server:stable
 
 # Name of the model that will be used as the based directory of the model files AND passed to openvino executable
 ARG MODEL_NAME
 # Location of the model files within the build context directory
 # Structure is based on OpenVino expectations of <BUILD_CONTEXT>/<MODEL_DIR>/<MODEL_VERSION>
-# See https://docs.openvino.ai/2024/ovms_docs_models_repository.html 
+# See https://docs.openvino.ai/2024/ovms_docs_models_repository.html
 ARG MODEL_DIR="."
 ARG GRPC_PORT=9090
 ARG REST_PORT=8080
@@ -22,9 +24,9 @@ RUN mkdir /models && chown ovms:ovms /models
 # the directory where we store the model and version
 COPY --chown=ovms:ovms $MODEL_DIR /models/$MODEL_NAME
 
-# Remove the TensorFlow fingerprint.pb file if found as it causes an error in OpenVino when multiple
+# Remove any TensorFlow fingerprint.pb file if found as it causes an error in OpenVino when multiple
 #   protobuf(.pb) files  are present in the model directory
-#   See https://www.tensorflow.org/guide/saved_model for info on the TensorFlow model
+#   See https://www.tensorflow.org/guide/saved_model for info on the TensorFlow model format
 # Set permissions so that the container can run locally OR on OpenShift
 RUN find /models -name fingerprint.pb -delete && chmod o+rwX /models/ && chgrp -R 0 /models
 

--- a/pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow
+++ b/pipelines/containerfiles/Containerfile.openvino.mlserver.mlflow
@@ -1,3 +1,7 @@
+# This ContainerFile is used to manually convert the MLFlow tensorflow-housing example to a format that works with the OpenVino Model Server
+# The tensorflow-housing example we provide in the ai-edge repo copies the tensorflow-housing/tf2model/{saved_model.pb,variables/} directory to a
+#   format that is compatible with OpenVino Model Server: /model/<MODEL VERSION>/<TENSORFLOW SAVED MODEL FORMAT>
+# TensorFlow example source - https://github.com/mlflow/mlflow/tree/ef0f922ca874dd94f9b88e8bfbde2a8cb2c385d2/examples/tensorflow
 FROM quay.io/opendatahub/openvino_model_server:stable
 
 ARG MODEL_NAME
@@ -18,7 +22,8 @@ RUN mkdir /models && chown ovms:ovms /models
 # CHANGE THIS LINE TO MATCH YOUR MODEL
 COPY --chown=ovms:ovms $MODEL_DIR /models/1
 
-                                # Not deleting this file causes a bug                                                # https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html#use-uid_create-images
+# Not deleting this file causes a bug
+# https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html#use-uid_create-images
 RUN if echo "${MODEL_DIR}" | grep -q "tf2model"; then rm -f /models/1/fingerprint.pb; fi && chmod o+rwX /models/1 && chgrp -R 0 /models/1 && chmod -R g=u /models/1
 
 EXPOSE $REST_PORT $GRPC_PORT

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -141,6 +141,8 @@ spec:
     params:
     - name: model-name
       value: $(params.model-name)
+    - name: model-relative-path
+      value: $(params.modelRelativePath)
     - name: current-namespace
       value: $(context.pipelineRun.namespace)
     - name: s3-bucket-name

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -10,7 +10,7 @@ spec:
   - default: "1"
     name: model-version
     type: string
-    description: Version of the model
+    description: Version of the model used for the base of the imagetag
   - name: s3-bucket-name
     type: string
     description: "[S3 ONLY] S3 bucket name where the model is stored"
@@ -257,6 +257,7 @@ spec:
               containers:
               - image: $(params.candidate-image-tag-reference)
                 name: $(params.model-name)-$(params.model-version)
+                imagePullPolicy: Always
                 livenessProbe:
                   failureThreshold: 10
                   httpGet:

--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.pipeline.yaml
@@ -322,7 +322,7 @@ spec:
         if [ "$(params.upon-end)" == "stop" ]; then
           oc scale deployment.apps/$(params.model-name)-$(params.model-version) --replicas=0
         elif [ "$(params.upon-end)" == "delete" ]; then
-          oc delete all --selector=app=$(params.model-name)-$(params.model-version)
+          oc delete deployment,service --selector=app=$(params.model-name)-$(params.model-version)
         elif [ "$(params.upon-end)" == "keep" ]; then
           echo "Keeping the deployment running."
         else

--- a/pipelines/tekton/aiedge-e2e/tasks/check-model-and-containerfile-exists.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/check-model-and-containerfile-exists.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: check-model-and-containerfile-exists
 spec:
-  description: This Task can be used to check if the model files and containerfile are present
+  description: This Task can be used to check if the model files and containerfile are present within the workspace
   params:
   - name: model-name
     type: string
@@ -27,7 +27,7 @@ spec:
 
       set -Eeuo pipefail
 
-      # Check model files exist
+      # Check model files exist based on where it is located within the workspace
       if [ -n "$(params.modelRelativePath)" ]; then
         ls -l model_dir-$(params.model-name)/$(params.modelRelativePath)/$(params.model-name)/ ;
 

--- a/pipelines/tekton/aiedge-e2e/tasks/kserve-download-model.yaml
+++ b/pipelines/tekton/aiedge-e2e/tasks/kserve-download-model.yaml
@@ -7,6 +7,9 @@ spec:
   params:
   - name: model-name
     type: string
+  - name: model-relative-path
+    type: string
+    default: ""
   - name: current-namespace
     default: "default"
     type: string
@@ -19,9 +22,23 @@ spec:
   - name: download-model-s3
     image: quay.io/opendatahub/kserve-storage-initializer:v0.11.1.3
     script: |
-      mkdir -p $(workspaces.workspace.path)/model_dir-$(params.model-name)/
+      WORKSPACE_DIR="$(workspaces.workspace.path)/model_dir-$(params.model-name)"
 
-      export S3_URL="s3://$(params.s3-bucket-name)/$(params.model-name)"
+      # This if statement is required because boto3 does not translate a `//` to a `/`
+      # when used inside a path similar to bash
+      if [ -n "$(params.model-relative-path)" ]; then
+        S3_URL="s3://$(params.s3-bucket-name)/$(params.model-relative-path)/$(params.model-name)"
+        # Include the model-relative-path in the local workspace directory to align with the
+        #  expectations when the model is fetched from a git repository where the relative path
+        #  is required
+        MODEL_DIR="$WORKSPACE_DIR/$(params.model-relative-path)/$(params.model-name)"
+      else
+        MODEL_DIR="$WORKSPACE_DIR/$(params.model-name)"
+        S3_URL="s3://$(params.s3-bucket-name)/$(params.model-name)"
+      fi
+
+      mkdir -p $MODEL_DIR
+
       echo -n $S3_URL | tee $(results.s3-url.path) ;
 
       if [ -n "$(workspaces.ssl-ca-directory.path)" ]; then
@@ -30,8 +47,7 @@ spec:
       fi
       
       STORAGE_CONFIG="$(cat $(workspaces.s3-secret.path)/s3-storage-config)" /storage-initializer/scripts/initializer-entrypoint \
-      $S3_URL \
-      $(workspaces.workspace.path)/model_dir-$(params.model-name)/$(params.model-name)
+      $S3_URL $MODEL_DIR
   workspaces:
   - description: The workspace for the downloaded model.
     name: workspace


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Updates the `fetch-model-s3` task to provide basic support for fetching a model from a sub directory under the S3 bucket removing the hardcoded requirement that all model directories be stored at the root of the S3 bucket.
* Adds a universal OpenVino containerfile that can build an inference container image for any supported OpenVino Model format

This provides the ability for users to utilize the [OpenShift AI Fraud Detection tutorial](https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.8/html/openshift_ai_tutorial_-_fraud_detection_example/index) in the workflow to train and deploy a model using our pipelines

Jira: [RHOAIENG-2244](https://issues.redhat.com/browse/RHOAIENG-2244)

## How Has This Been Tested?
* Followed the RHOAI Fraud Detection example to train a model and used that with minio and our Pipeline
OR
* Fetch the `fraud-detection` model from `s3://rhoai-edge/example-models/fraud-detection`

The `test-model-rest-svc` must be updated to match output based on the `data:` not `prediction:`

The `Continerfile.openvino` to build the inferencing container must be used with this model 

## Merge criteria:
Existing pipeline workflows for `bike-rental` and `tensorflow-housing` are not affected


- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
