### PR TITLE
RHOAIENG-4703: Add e2e-tests in Go to verify the GitOps pipeline is working correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ GOFLAGS=""
 #   IMAGE_REGISTRY_PASSWORD     - quay.io password
 #   GIT_SELF_SIGNED_CERT        - Self-signed cert to be used in pipeline by git (optional)
 #   S3_SELF_SIGNED_CERT         - Self-signed cert to be used in pipeline by the script that's used to download the model from S3-compatible object storage (optional)
-#   GIT_TOKEN
-#   GIT_USERNAME
+#   GIT_TOKEN                   - Auth token used by the git ops pipeline to make a pull request
+#   GIT_USERNAME                - Username linked to the GIT_TOKEN
 go-test-setup:
 ifndef AWS_SECRET_ACCESS_KEY
 	$(error AWS_SECRET_ACCESS_KEY is undefined)
@@ -90,9 +90,9 @@ endif
 #   TARGET_IMAGE_TAGS_JSON  - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
 #   GIT_SELF_SIGNED_CERT    - Self-signed cert to be used in pipeline by git (optional)
 #   S3_SELF_SIGNED_CERT     - Self-signed cert to be used in pipeline by the script that's used to download the model from S3-compatible object storage (optional)
-#   GIT_REPO
-#   GIT_API_SERVER
-#   GIT_BRANCH 
+#   GIT_REPO                - Git repo URL used to make a pull request in the git ops pipeline (https://github.com/org/repo)
+#   GIT_API_SERVER          - Git API server (api.github.com)
+#   GIT_BRANCH              - Base branch used for pull request in git ops pipeline
 go-test:
 ifndef S3_BUCKET
 	$(error S3_BUCKET is undefined)

--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,12 @@ ifndef GIT_USERNAME
 	$(error GIT_USERNAME is undefined)
 endif
 	# MLOps pipieline setup
-	@sed -e "s#{{ AWS_SECRET_ACCESS_KEY }}#${AWS_SECRET_ACCESS_KEY}#g" -e "s#{{ AWS_ACCESS_KEY_ID }}#${AWS_ACCESS_KEY_ID}#g" -e "s#{{ S3_REGION }}#${S3_REGION}#g" -e "s#{{ S3_ENDPOINT }}#${S3_ENDPOINT}#g" pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template | oc create -f -
-	@sed -e "s#{{ IMAGE_REGISTRY_USERNAME }}#${IMAGE_REGISTRY_USERNAME}#g" -e "s#{{ IMAGE_REGISTRY_PASSWORD }}#${IMAGE_REGISTRY_PASSWORD}#g" pipelines/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template | oc create -f -
+	@sed -e "s#{{ AWS_SECRET_ACCESS_KEY }}#${AWS_SECRET_ACCESS_KEY}#g" -e "s#{{ AWS_ACCESS_KEY_ID }}#${AWS_ACCESS_KEY_ID}#g" -e "s#{{ S3_REGION }}#${S3_REGION}#g" -e "s#{{ S3_ENDPOINT }}#${S3_ENDPOINT}#g" pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template | oc apply -f -
+	@sed -e "s#{{ IMAGE_REGISTRY_USERNAME }}#${IMAGE_REGISTRY_USERNAME}#g" -e "s#{{ IMAGE_REGISTRY_PASSWORD }}#${IMAGE_REGISTRY_PASSWORD}#g" pipelines/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template | oc apply -f -
 	oc secret link pipeline credentials-image-registry
 
 	# GITOps pipeline setup
-	sed -e "s#{username}#${GIT_USERNAME}#g" -e "s#{github_pat_1234567890ABCDAPI_TOKEN}#${GIT_TOKEN}#g" pipelines/tekton/gitops-update-pipeline/example-pipelineruns/example-git-credentials-secret.yaml | oc create -f -
+	sed -e "s#{username}#${GIT_USERNAME}#g" -e "s#{github_pat_1234567890ABCDAPI_TOKEN}#${GIT_TOKEN}#g" pipelines/tekton/gitops-update-pipeline/example-pipelineruns/example-git-credentials-secret.yaml | oc apply -f -
 
 
 # requires:

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ GOFLAGS=""
 #   IMAGE_REGISTRY_PASSWORD     - quay.io password
 #   GIT_SELF_SIGNED_CERT        - Self-signed cert to be used in pipeline by git (optional)
 #   S3_SELF_SIGNED_CERT         - Self-signed cert to be used in pipeline by the script that's used to download the model from S3-compatible object storage (optional)
+#   GIT_TOKEN
+#   GIT_USERNAME
 go-test-setup:
 ifndef AWS_SECRET_ACCESS_KEY
 	$(error AWS_SECRET_ACCESS_KEY is undefined)
@@ -67,9 +69,20 @@ endif
 ifdef S3_SELF_SIGNED_CERT
 	oc create configmap s3-self-signed-cert --from-file=ca-bundle.crt=${S3_SELF_SIGNED_CERT}
 endif
+ifndef GIT_TOKEN
+	$(error GIT_TOKEN is undefined)
+endif
+ifndef GIT_USERNAME
+	$(error GIT_USERNAME is undefined)
+endif
+	# MLOps pipieline setup
 	@sed -e "s#{{ AWS_SECRET_ACCESS_KEY }}#${AWS_SECRET_ACCESS_KEY}#g" -e "s#{{ AWS_ACCESS_KEY_ID }}#${AWS_ACCESS_KEY_ID}#g" -e "s#{{ S3_REGION }}#${S3_REGION}#g" -e "s#{{ S3_ENDPOINT }}#${S3_ENDPOINT}#g" pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template | oc create -f -
 	@sed -e "s#{{ IMAGE_REGISTRY_USERNAME }}#${IMAGE_REGISTRY_USERNAME}#g" -e "s#{{ IMAGE_REGISTRY_PASSWORD }}#${IMAGE_REGISTRY_PASSWORD}#g" pipelines/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template | oc create -f -
 	oc secret link pipeline credentials-image-registry
+
+	# GITOps pipeline setup
+	sed -e "s#{username}#${GIT_USERNAME}#g" -e "s#{github_pat_1234567890ABCDAPI_TOKEN}#${GIT_TOKEN}#g" pipelines/tekton/gitops-update-pipeline/example-pipelineruns/example-git-credentials-secret.yaml | oc create -f -
+
 
 # requires:
 #   S3_BUCKET               - Name of S3 bucket that contains the models
@@ -77,6 +90,9 @@ endif
 #   TARGET_IMAGE_TAGS_JSON  - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
 #   GIT_SELF_SIGNED_CERT    - Self-signed cert to be used in pipeline by git (optional)
 #   S3_SELF_SIGNED_CERT     - Self-signed cert to be used in pipeline by the script that's used to download the model from S3-compatible object storage (optional)
+#   GIT_REPO
+#   GIT_API_SERVER
+#   GIT_BRANCH 
 go-test:
 ifndef S3_BUCKET
 	$(error S3_BUCKET is undefined)
@@ -87,7 +103,16 @@ endif
 ifndef TARGET_IMAGE_TAGS_JSON
 	$(error TARGET_IMAGE_TAGS_JSON is undefined)
 endif
-	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} GIT_SELF_SIGNED_CERT=${GIT_SELF_SIGNED_CERT} S3_SELF_SIGNED_CERT=${S3_SELF_SIGNED_CERT} ${GO} test -timeout 30m)
+ifndef GIT_REPO
+	$(error GIT_REPO is undefined)
+endif
+ifndef GIT_API_SERVER
+	$(error GIT_API_SERVER is undefined)
+endif
+ifndef GIT_BRANCH
+	$(error GIT_BRANCH is undefined)
+endif
+	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} GIT_SELF_SIGNED_CERT=${GIT_SELF_SIGNED_CERT} S3_SELF_SIGNED_CERT=${S3_SELF_SIGNED_CERT} GIT_REPO=${GIT_REPO} GIT_API_SERVER=${GIT_API_SERVER} GIT_BRANCH=${GIT_BRANCH} ${GO} test -timeout 30m -shuffle off)
 
 test:
 	${MAKE} -C cli cli-test

--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,25 @@ ifndef GIT_USERNAME
 	$(error GIT_USERNAME is undefined)
 endif
 	# MLOps pipieline setup
-	@sed -e "s#{{ AWS_SECRET_ACCESS_KEY }}#${AWS_SECRET_ACCESS_KEY}#g" -e "s#{{ AWS_ACCESS_KEY_ID }}#${AWS_ACCESS_KEY_ID}#g" -e "s#{{ S3_REGION }}#${S3_REGION}#g" -e "s#{{ S3_ENDPOINT }}#${S3_ENDPOINT}#g" pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template | oc apply -f -
-	@sed -e "s#{{ IMAGE_REGISTRY_USERNAME }}#${IMAGE_REGISTRY_USERNAME}#g" -e "s#{{ IMAGE_REGISTRY_PASSWORD }}#${IMAGE_REGISTRY_PASSWORD}#g" pipelines/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template | oc apply -f -
+	@sed \
+	-e "s#{{ AWS_SECRET_ACCESS_KEY }}#${AWS_SECRET_ACCESS_KEY}#g" \
+	-e "s#{{ AWS_ACCESS_KEY_ID }}#${AWS_ACCESS_KEY_ID}#g" \
+	-e "s#{{ S3_REGION }}#${S3_REGION}#g" \
+	-e "s#{{ S3_ENDPOINT }}#${S3_ENDPOINT}#g" \
+	pipelines/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template | oc apply -f -
+
+	@sed \
+	-e "s#{{ IMAGE_REGISTRY_USERNAME }}#${IMAGE_REGISTRY_USERNAME}#g"  \
+	-e "s#{{ IMAGE_REGISTRY_PASSWORD }}#${IMAGE_REGISTRY_PASSWORD}#g" \
+	pipelines/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template | oc apply -f -
+
 	oc secret link pipeline credentials-image-registry
 
 	# GITOps pipeline setup
-	sed -e "s#{username}#${GIT_USERNAME}#g" -e "s#{github_pat_1234567890ABCDAPI_TOKEN}#${GIT_TOKEN}#g" pipelines/tekton/gitops-update-pipeline/example-pipelineruns/example-git-credentials-secret.yaml | oc apply -f -
+	@sed -e \
+	"s#{username}#${GIT_USERNAME}#g" \
+	-e "s#{github_pat_1234567890ABCDAPI_TOKEN}#${GIT_TOKEN}#g" \
+	pipelines/tekton/gitops-update-pipeline/example-pipelineruns/example-git-credentials-secret.yaml | oc apply -f -
 
 
 # requires:
@@ -112,7 +125,16 @@ endif
 ifndef GIT_BRANCH
 	$(error GIT_BRANCH is undefined)
 endif
-	(cd test/e2e-tests/tests && S3_BUCKET=${S3_BUCKET} TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} NAMESPACE=${NAMESPACE} GIT_SELF_SIGNED_CERT=${GIT_SELF_SIGNED_CERT} S3_SELF_SIGNED_CERT=${S3_SELF_SIGNED_CERT} GIT_REPO=${GIT_REPO} GIT_API_SERVER=${GIT_API_SERVER} GIT_BRANCH=${GIT_BRANCH} ${GO} test -timeout 30m -shuffle off)
+	(cd test/e2e-tests/tests && \ 
+	S3_BUCKET=${S3_BUCKET} \
+	TARGET_IMAGE_TAGS_JSON=${TARGET_IMAGE_TAGS_JSON} \
+	NAMESPACE=${NAMESPACE} \
+	GIT_SELF_SIGNED_CERT=${GIT_SELF_SIGNED_CERT} \
+	S3_SELF_SIGNED_CERT=${S3_SELF_SIGNED_CERT} \
+	GIT_REPO=${GIT_REPO} \
+	GIT_API_SERVER=${GIT_API_SERVER} \
+	GIT_BRANCH=${GIT_BRANCH} \
+	${GO} test -timeout 30m -shuffle off)
 
 test:
 	${MAKE} -C cli cli-test

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -24,6 +24,7 @@ The following enviroment variables are optional. You may still need to set them 
 - `GIT_SELF_SIGNED_CERT` - Self-signed cert to be used by git when cloning
 - `S3_SELF_SIGNED_CERT` - Self-signed cert to be used for S3 when pulling models
 
+Run `go-test-setup` to get the namespace ready for testing. This target is only expected to be run once, if you want to re-run the tests in the same namespace you can just re-run the `go-test` target, read the next section for more detail.
 
 ```bash
 make go-test-setup
@@ -53,6 +54,8 @@ Set the go binary used for testing that is in your `PATH`
 ```bash
 make GO=go1.19 go-test
 ```
+
+If you want to re-run the tests in the same namespace you can just re-run the `go-test` target. The tests fail if there are **any** failed pipeline runs. Therefore if you have a failed run and want to re-test make sure to delete any that have failed.
 
 ## CI/CD with Github Actions
 Not yet implemented

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -16,6 +16,8 @@ The following enviroment variables are required to run the test setup and the te
 - `S3_ENDPOINT` - Endpint of the bucket
 - `IMAGE_REGISTRY_USERNAME` - quay.io username
 - `IMAGE_REGISTRY_PASSWORD` - quay.io password
+- `GIT_TOKEN` - Auth token used by the git ops pipeline to make a pull request, [see info here](../../pipelines/README.md#git-repository-and-credentials)
+- `GIT_USERNAME` - Username linked to the `GIT_TOKEN`
 
 The following enviroment variables are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 
@@ -31,9 +33,12 @@ make go-test-setup
 
 The following enviroment variables are required to run the tests. If any of these are not set then the tests will not run. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 
-- `S3_BUCKET`	- Name of S3 bucket that contains the models
-- `NAMESPACE`	- Cluster namespace that tests are run in
-- `TARGET_IMAGE_TAGS_JSON`	- JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
+- `S3_BUCKET` - Name of S3 bucket that contains the models
+- `NAMESPACE` - Cluster namespace that tests are run in
+- `TARGET_IMAGE_TAGS_JSON` - JSON array of image tags that the final image will be pushed to. E.g. '["quay.io/user/model-name:e2e-test"]'
+- `GIT_REPO` - Git repo URL used to make a pull request in the git ops pipeline (https://github.com/org/repo)
+- `GIT_API_SERVER` - Git API server (api.github.com)
+- `GIT_BRANCH` - Base branch used for pull request in git ops pipeline
 
 The following enviroment variables are optional. You may still need to set them for the tests to pass depending on your setup. Read [here](../../pipelines/README.md#ai-edge-end-to-end-pipeline) for more context on how to set these up.
 

--- a/test/e2e-tests/support/git.go
+++ b/test/e2e-tests/support/git.go
@@ -1,0 +1,34 @@
+package support
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type GitRepoURL struct {
+	Server   string
+	OrgName  string
+	RepoName string
+}
+
+func ParseGitURL(rawURL string) (GitRepoURL, error) {
+	gitRepoURL := GitRepoURL{}
+
+	URL, err := url.Parse(rawURL)
+	if err != nil {
+		return gitRepoURL, err
+	}
+
+	// using trim here aswell because leading and trailing / causes empty strings when slicing
+	subPaths := strings.Split(strings.Trim(URL.Path, "/"), "/")
+	if len(subPaths) != 2 {
+		return gitRepoURL, fmt.Errorf("cannot parse git repo URL, expected [scheme]://[host]/[org]/[repo] got %v", rawURL)
+	}
+
+	gitRepoURL.OrgName = subPaths[0]
+	gitRepoURL.RepoName = subPaths[1]
+	gitRepoURL.Server = fmt.Sprintf("%v://%v", URL.Scheme, URL.Host)
+
+	return gitRepoURL, nil
+}

--- a/test/e2e-tests/support/options.go
+++ b/test/e2e-tests/support/options.go
@@ -12,6 +12,9 @@ const (
 	ClusterNamespaceEnvKey  = "NAMESPACE"
 	GitSelfSignedCertEnvKey = "GIT_SELF_SIGNED_CERT"
 	S3SelfSignedCertEnvKey  = "S3_SELF_SIGNED_CERT"
+	GitRepoEnvKey           = "GIT_REPO"
+	GitAPIServerEnvKey      = "GIT_API_SERVER"
+	GitBranchEnvKey         = "GIT_BRANCH"
 )
 
 var (
@@ -19,11 +22,18 @@ var (
 )
 
 type Options struct {
+	ClusterNamespace string // required
+
+	// MLOPs pipeline specific options
 	S3BucketName             string   // required
-	ClusterNamespace         string   // required
 	TargetImageTagReferences []string // required
 	GitSelfSignedCert        string   // optional
 	S3SelfSignedCert         string   // optional
+
+	// GitOPs pipeline specific options
+	GitRepo      string // required
+	GitAPIServer string // required
+	GitBranch    string // required
 }
 
 func GetOptions() (*Options, error) {
@@ -65,6 +75,18 @@ func setOptions() (*Options, error) {
 
 	if options.S3SelfSignedCert = os.Getenv(S3SelfSignedCertEnvKey); options.S3SelfSignedCert == "" {
 		fmt.Printf("\noptional env variable %v not set, set it to use self-signed certs with S3", S3SelfSignedCertEnvKey)
+	}
+
+	if options.GitRepo = os.Getenv(GitRepoEnvKey); options.GitRepo == "" {
+		return options, fmt.Errorf("env variable %v not set, but is required to run tests", GitRepoEnvKey)
+	}
+
+	if options.GitAPIServer = os.Getenv(GitAPIServerEnvKey); options.GitAPIServer == "" {
+		return options, fmt.Errorf("env variable %v not set, but is required to run tests", GitAPIServerEnvKey)
+	}
+
+	if options.GitBranch = os.Getenv(GitBranchEnvKey); options.GitBranch == "" {
+		return options, fmt.Errorf("env variable %v not set, but is required to run tests", GitBranchEnvKey)
 	}
 
 	return options, nil

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	MLOpsPipelineDirectoryRelativePath            = "../../../pipelines/tekton/aiedge-e2e"
-	MLOpsBikeRentalsPipelineRunRelativePath       = MLOpsPipelineDirectoryRelativePath + "/aiedge-e2e.bike-rentals.pipelinerun.yaml"
-	MLOpsTensorflowHousingPipelineRunRelativePath = MLOpsPipelineDirectoryRelativePath + "/aiedge-e2e.tensorflow-housing.pipelinerun.yaml"
+	AIEdgeE2EPipelineDirectoryRelativePath            = "../../../pipelines/tekton/aiedge-e2e"
+	AIEdgeE2EBikeRentalsPipelineRunRelativePath       = AIEdgeE2EPipelineDirectoryRelativePath + "/aiedge-e2e.bike-rentals.pipelinerun.yaml"
+	AIEdgeE2ETensorflowHousingPipelineRunRelativePath = AIEdgeE2EPipelineDirectoryRelativePath + "/aiedge-e2e.tensorflow-housing.pipelinerun.yaml"
 
-	GitOpsPipelineDirectoryRelativePath            = "../../../pipelines/tekton/gitops-update-pipeline"
-	GitOpsBikeRentalsPipelineRunRelativePath       = GitOpsPipelineDirectoryRelativePath + "/example-pipelineruns/gitops-update-pipelinerun-bike-rentals.yaml"
-	GitOpsTensorflowHousingPipelineRunRelativePath = GitOpsPipelineDirectoryRelativePath + "/example-pipelineruns/gitops-update-pipelinerun-tensorflow-housing.yaml"
+	GitOpsUpdatePipelineDirectoryRelativePath            = "../../../pipelines/tekton/gitops-update-pipeline"
+	GitOpsUpdateBikeRentalsPipelineRunRelativePath       = GitOpsUpdatePipelineDirectoryRelativePath + "/example-pipelineruns/gitops-update-pipelinerun-bike-rentals.yaml"
+	GitOpsUpdateTensorflowHousingPipelineRunRelativePath = GitOpsUpdatePipelineDirectoryRelativePath + "/example-pipelineruns/gitops-update-pipelinerun-tensorflow-housing.yaml"
 )
 
 func CreateContext() context.Context {
@@ -73,7 +73,7 @@ func init() {
 		panic(fmt.Sprintf("error while creating client : %v", err.Error()))
 	}
 
-	kustomizePaths := []string{MLOpsPipelineDirectoryRelativePath, GitOpsPipelineDirectoryRelativePath}
+	kustomizePaths := []string{AIEdgeE2EPipelineDirectoryRelativePath, GitOpsUpdatePipelineDirectoryRelativePath}
 
 	for _, path := range kustomizePaths {
 		resourceMap, err := support.KustomizeBuild(path)
@@ -102,7 +102,7 @@ func Test_MLOpsPipelineRunsComplete(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	pipelineRunPaths := []string{MLOpsTensorflowHousingPipelineRunRelativePath, MLOpsBikeRentalsPipelineRunRelativePath}
+	pipelineRunPaths := []string{AIEdgeE2ETensorflowHousingPipelineRunRelativePath, AIEdgeE2EBikeRentalsPipelineRunRelativePath}
 
 	for _, path := range pipelineRunPaths {
 		pipelineRun, err := support.ReadFileAsPipelineRun(path)
@@ -146,7 +146,7 @@ func Test_GitOpsPipelineRunsComplete(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	pipelineRunPaths := []string{GitOpsTensorflowHousingPipelineRunRelativePath, GitOpsBikeRentalsPipelineRunRelativePath}
+	pipelineRunPaths := []string{GitOpsUpdateTensorflowHousingPipelineRunRelativePath, GitOpsUpdateBikeRentalsPipelineRunRelativePath}
 
 	gitURL, err := support.ParseGitURL(options.GitRepo)
 	if err != nil {


### PR DESCRIPTION
## Description
Adds support for testing the git ops pipeline with the go e2e test suite 

## Verify steps
- Log into a cluster with `oc`
- Set the list of enviroment variables that are needed for running the tests for both the `go-test` and `go-test-setup` make targets. All of the required fields are listed [here](https://github.com/jackdelahunt/ai-edge/tree/git-ops-e2e-tests/test/e2e-tests) in the README
- Run `oc new-project {YOURNAMESPACE}`
- Run `make AWS_SECRET=... AWS_ACCESS=...  ... go-test-setup`
- Run `make S3_BUCKET=...  ... go-test`
- All tests should pass

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
