### PR TITLE
Remove emptyDir workspace from bike-rentals pipelinerun

### DIFF
--- a/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
+++ b/pipelines/tekton/aiedge-e2e/aiedge-e2e.bike-rentals.pipelinerun.yaml
@@ -56,8 +56,6 @@ spec:
   - name: s3-secret
     secret:
         secretName: credentials-s3
-  - emptyDir: {}
-    name: workspace
   - configMap:
       name: bike-rentals-test-data
     name: test-data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`emptyDir` workspace named `workspace` is no longer needed as it was removed in https://github.com/opendatahub-io/ai-edge/commit/e1cfc6839c7ec44bd5f5e7e54c31cc8cd22276c5#diff-f322a0b0f23c8b879c98be3845b85e495e33da44e440b107f89b6a538c9861d4L380 but it was removed just from the `tensorflow-housing` pipeline run.

## How Has This Been Tested?
Locally & PR check

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
