### PR TITLE
test/acm: Remove Policy from kustomize

### DIFF
--- a/test/acm/bike-rental-app/kustomization.yaml
+++ b/test/acm/bike-rental-app/kustomization.yaml
@@ -22,15 +22,6 @@ patches:
       value: custom-app-namespace
   target:
     kind: ApplicationSet
-- patch: |-
-    - op: replace
-      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
-      value: custom-app-namespace
-    - op: replace
-      path: /spec/policy-templates/0/objectDefinition/metadata/name
-      value: custom-app-namespace-has-argo-label
-  target:
-    kind: Policy
 
 replacements:
 - source:
@@ -53,13 +44,3 @@ replacements:
       kind: PlacementBinding
     fieldPaths:
       - placementRef.name
-- source:
-    kind: Policy
-    group: policy.open-cluster-management.io
-    fieldPath: metadata.name
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: PlacementBinding
-    fieldPaths:
-      - subjects.0.name

--- a/test/acm/tensorflow-housing-app/kustomization.yaml
+++ b/test/acm/tensorflow-housing-app/kustomization.yaml
@@ -22,15 +22,6 @@ patches:
       value: custom-app-namespace
   target:
     kind: ApplicationSet
-- patch: |-
-    - op: replace
-      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/metadata/name
-      value: custom-app-namespace
-    - op: replace
-      path: /spec/policy-templates/0/objectDefinition/metadata/name
-      value: custom-app-namespace-has-argo-label
-  target:
-    kind: Policy
 
 replacements:
 - source:
@@ -53,13 +44,3 @@ replacements:
       kind: PlacementBinding
     fieldPaths:
       - placementRef.name
-- source:
-    kind: Policy
-    group: policy.open-cluster-management.io
-    fieldPath: metadata.name
-  targets:
-  - select:
-      group: policy.open-cluster-management.io
-      kind: PlacementBinding
-    fieldPaths:
-      - subjects.0.name


### PR DESCRIPTION


## Description
While going through https://github.com/opendatahub-io/ai-edge/pull/259/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R31 I found out that the `make` `test-acm-%-generate` target doesn't work because the Policy has been removed as a part of #229. This results in the following error:
`Error: nothing selected by Policy.[noVer].policy.open-cluster-management.io/[noName].[noNs]:metadata.name`
which stems from the replacement's `source` part.

Therefore, this PR removes the Policy targets and sources as well as patch references, which makes the make target functional again.
A similar removal has already been done in https://github.com/opendatahub-io/ai-edge/pull/233.

## How Has This Been Tested?
From the root of the repository run:
```shell
make GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" GIT_BRANCH=my-git-branch CUSTOM_PREFIX=custom- CUSTOM_APP_NAMESPACE=custom-tensorflow-housing test-acm-bike-rental-app-generate
```
```shell
make GIT_REPO_URL="https\://github.com/opendatahub-io/ai-edge" GIT_BRANCH=my-git-branch CUSTOM_PREFIX=custom- CUSTOM_APP_NAMESPACE=custom-tensorflow-housing test-acm-tensorflow-housing-app-generate
```
Both should output yaml definitions without throwing an error.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
