### PR TITLE
Delete unused parameters from pipeline and tasks

### DIFF
--- a/manifests/pipelines/aiedge-e2e.pipeline.yaml
+++ b/manifests/pipelines/aiedge-e2e.pipeline.yaml
@@ -156,8 +156,6 @@ spec:
     params:
     - name: model-name
       value: $(params.model-name)
-    - name: current-namespace
-      value: $(context.pipelineRun.namespace)
     - name: s3-bucket-name
       value: $(params.s3-bucket-name)
     - name: model-relative-path
@@ -203,8 +201,6 @@ spec:
       value: $(params.model-name)
     - name: containerfilePath
       value: containerfile_repo/$(params.containerfileRelativePath)
-    - name: current-namespace
-      value: $(context.pipelineRun.namespace)
     runAfter:
     - git-clone-containerfile-repo
     taskRef:

--- a/manifests/pipelines/gitops-update-pipeline.yaml
+++ b/manifests/pipelines/gitops-update-pipeline.yaml
@@ -4,8 +4,6 @@ metadata:
   name: gitops-update-pipeline
 spec:
   params:
-    - name: model-name
-      type: string
     - name: image-registry-repo
       type: string
     - name: image-digest

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -101,8 +101,6 @@ spec:
     params:
     - name: model-name
       value: $(params.model-name)
-    - name: current-namespace
-      value: $(context.pipelineRun.namespace)
     - name: s3-bucket-name
       value: $(params.s3-bucket-name)
     - name: model-relative-path
@@ -143,8 +141,6 @@ spec:
       value: $(params.model-name)
     - name: containerfilePath
       value: containerfile_repo/$(params.containerfile-relative-path)
-    - name: current-namespace
-      value: $(context.pipelineRun.namespace)
     runAfter:
     - git-clone-containerfile-repo
     taskRef:

--- a/manifests/tasks/check-model-and-containerfile-exists.yaml
+++ b/manifests/tasks/check-model-and-containerfile-exists.yaml
@@ -7,9 +7,6 @@ spec:
   params:
   - name: model-name
     type: string
-  - name: current-namespace 
-    default: "default"
-    type: string
   - name: containerfilePath
     type: string
   results:

--- a/manifests/tasks/kserve-download-model.yaml
+++ b/manifests/tasks/kserve-download-model.yaml
@@ -7,9 +7,6 @@ spec:
   params:
   - name: model-name
     type: string
-  - name: current-namespace
-    default: "default"
-    type: string
   - name: s3-bucket-name
     type: string
   - name: model-relative-path

--- a/pipelines/tekton/gitops-update-pipeline/example-pipelineruns/gitops-update-pipelinerun-bike-rentals.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/example-pipelineruns/gitops-update-pipelinerun-bike-rentals.yaml
@@ -6,8 +6,6 @@ metadata:
     tekton.dev/pipeline: gitops-update-pipeline
 spec:
   params:
-  - name: model-name
-    value: bike-rentals-auto-ml
   - name: image-registry-repo
     value: quay.io/rhoai-edge/bike-rentals-auto-ml
   - name: image-digest

--- a/pipelines/tekton/gitops-update-pipeline/example-pipelineruns/gitops-update-pipelinerun-json.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/example-pipelineruns/gitops-update-pipelinerun-json.yaml
@@ -6,8 +6,6 @@ metadata:
     tekton.dev/pipeline: gitops-update-pipeline
 spec:
   params:
-  - name: model-name
-    value: tensorflow-housing
   - name: image-registry-repo
     value: quay.io/rhoai-edge/tensorflow-housing
   - name: image-digest

--- a/pipelines/tekton/gitops-update-pipeline/example-pipelineruns/gitops-update-pipelinerun-tensorflow-housing.yaml
+++ b/pipelines/tekton/gitops-update-pipeline/example-pipelineruns/gitops-update-pipelinerun-tensorflow-housing.yaml
@@ -6,8 +6,6 @@ metadata:
     tekton.dev/pipeline: gitops-update-pipeline
 spec:
   params:
-  - name: model-name
-    value: tensorflow-housing
   - name: image-registry-repo
     value: quay.io/rhoai-edge/tensorflow-housing
   - name: image-digest


### PR DESCRIPTION
## Description
This removes 2 unused parameters:
* `current-namespace` from `check-model-and-containerfile-exists` and `kserve-download-model` tasks
* `model-name` from `gitops-update-pipeline`

## How Has This Been Tested?
PR check

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
