### PR TITLE
Fix bike-rentals-auto-ml

### DIFF
--- a/pipelines/containerfiles/Containerfile.seldonio.mlserver.mlflow
+++ b/pipelines/containerfiles/Containerfile.seldonio.mlserver.mlflow
@@ -6,7 +6,7 @@ USER root
 
 # Install miniconda as a helper to create a portable python environment
 RUN mkdir -p ~/miniconda3 && \
-  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \
+  wget --show-progress=off https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \
   bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3 && \
   rm -rf ~/miniconda3/miniconda.sh
 
@@ -18,7 +18,6 @@ COPY $MODEL_DIR /opt/app-root/src/model/
 RUN . ~/miniconda3/bin/activate && \
   conda env create -n mlflow-env -f model/conda.yaml && \
   conda activate mlflow-env && \
-  pip install mlserver-mlflow && \
   conda list && \
   conda deactivate && \
   conda activate && \
@@ -26,7 +25,7 @@ RUN . ~/miniconda3/bin/activate && \
   conda-pack -n mlflow-env -o model/environment.tar.gz
 
 # Create the MLServer container. Use the slim image, since we are providing an environment tarball.
-# 
+#
 FROM docker.io/seldonio/mlserver:1.3.5-slim
 
 ARG MODEL_NAME

--- a/pipelines/models/bike-rentals-auto-ml/conda.yaml
+++ b/pipelines/models/bike-rentals-auto-ml/conda.yaml
@@ -114,7 +114,9 @@ dependencies:
   - matplotlib==3.7.1
   - matplotlib-inline==0.1.6
   - ml-wrappers==0.4.7
-  - mlflow-skinny==2.2.2
+  - mlflow==2.14.3
+  - mlflow-skinny==2.14.3
+  - mlserver-mlflow==1.4.0
   - mltable==1.3.0
   - msal==1.21.0
   - msal-extensions==1.0.0

--- a/pipelines/models/bike-rentals-auto-ml/requirements.txt
+++ b/pipelines/models/bike-rentals-auto-ml/requirements.txt
@@ -108,7 +108,9 @@ markupsafe==2.1.2
 matplotlib==3.7.1
 matplotlib-inline==0.1.6
 ml-wrappers==0.4.7
-mlflow-skinny==2.2.2
+mlflow==2.14.3
+mlflow-skinny==2.14.3
+mlserver-mlflow==1.4.0
 mltable==1.3.0
 msal==1.21.0
 msal-extensions==1.0.0


### PR DESCRIPTION
## Description
`mlserver-flow` depends on `mlserver` without any version restrictions, so it pulls the latest one. [Yesterday, mlserver 2.15.0 was released](https://pypi.org/project/mlflow/2.15.0/#history) which is apparently not compatible with the rest in runtime, preventing model container to start. So I added the previous version 2.14.3, which worked fine, as a requirement.

## How Has This Been Tested?
PR check

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
