### PR TITLE
RHOAIENG-6634: Test stage can use wrong image, because of tag reference and imagePullPolicy

### DIFF
--- a/manifests/pipelines/aiedge-e2e.pipeline.yaml
+++ b/manifests/pipelines/aiedge-e2e.pipeline.yaml
@@ -264,7 +264,7 @@ spec:
                 app: $(params.model-name)-$(params.model-version)
             spec:
               containers:
-              - image: $(params.candidate-image-tag-reference)
+              - image: $(params.candidate-image-tag-reference)@$(tasks.build-container-image.results.IMAGE_DIGEST)
                 name: $(params.model-name)-$(params.model-version)
                 livenessProbe:
                   failureThreshold: 10

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -204,7 +204,7 @@ spec:
                 app: $(params.model-name)-$(params.model-version)
             spec:
               containers:
-              - image: $(params.candidate-image-tag-reference)
+              - image: $(params.candidate-image-tag-reference)@$(tasks.build-container-image.results.IMAGE_DIGEST)
                 name: $(params.model-name)-$(params.model-version)
                 livenessProbe:
                   failureThreshold: 10


### PR DESCRIPTION
**changes only applied to aiedge pipeline so far**

## Description
In the test stage of the aiedge-e2e pipeline, we deploy the built image by referring to it by the tag reference (rather than manifest digest reference), and we don't explicitly set the imagePullPolicy to Always. This can lead to difficult to a case where an older candidate image is already stored on the node from a previous run, and won't be refreshed before deploying. This could mean that the new image doesn't actually get tested.

## How Has This Been Tested?
- CI
- Run e2e tests as normal and all should pass

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
