### PR TITLE
RHOAIENG-371: Add pipeline support for git private repo using an authentication token

### DIFF
--- a/examples/tekton/aiedge-e2e/templates/credentials-git.secret.yaml.template
+++ b/examples/tekton/aiedge-e2e/templates/credentials-git.secret.yaml.template
@@ -4,10 +4,6 @@ metadata:
   name: credentials-git
 type: Opaque
 stringData:
-  # This "token" field is used for interacting with the GitHub API to
-  # create a pull request. Change the value to a token from your
-  # GitHub-compatible forge.
-  token: "{github_pat_1234567890ABCDAPI_TOKEN}"
   # This .git-credentials field is used to specify credentials when
   # interacting with a Git server (clone/fetch/push). It will be
   # placed as a file on disk so that the Git CLI can use it, so change

--- a/examples/tekton/aiedge-e2e/templates/credentials-git.secret.yaml.template
+++ b/examples/tekton/aiedge-e2e/templates/credentials-git.secret.yaml.template
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret 
+metadata:
+  name: credentials-git
+type: Opaque
+stringData:
+  # This "token" field is used for interacting with the GitHub API to
+  # create a pull request. Change the value to a token from your
+  # GitHub-compatible forge.
+  token: "{github_pat_1234567890ABCDAPI_TOKEN}"
+  # This .git-credentials field is used to specify credentials when
+  # interacting with a Git server (clone/fetch/push). It will be
+  # placed as a file on disk so that the Git CLI can use it, so change
+  # it to appropriate details for your Git server.
+  .git-credentials: "https://{username}:{github_pat_1234567890ABCDAPI_TOKEN}@github.com"
+  .gitconfig: |
+    [credential]
+      helper = store

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -122,6 +122,8 @@ spec:
       workspace: build-workspace-pv
     - name: ssl-ca-directory
       workspace: git-ssl-cert
+    - name: basic-auth
+      workspace: git-secret
   - name: move-model-to-root-dir
     params:
     - name: model-name
@@ -355,6 +357,8 @@ spec:
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv
+  - name: git-secret
+    optional: true
   - name: git-basic-auth
     optional: true
   - name: test-data

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -123,7 +123,7 @@ spec:
     - name: ssl-ca-directory
       workspace: git-ssl-cert
     - name: basic-auth
-      workspace: git-secret
+      workspace: git-basic-auth
   - name: move-model-to-root-dir
     params:
     - name: model-name
@@ -357,8 +357,6 @@ spec:
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv
-  - name: git-secret
-    optional: true
   - name: git-basic-auth
     optional: true
   - name: test-data

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -33,6 +33,8 @@ These are all the fields in `git_fetch`
 - `model_relative_path` - Relative path from the root of the model repo to where the model is 
 - `model_revision` - Branch of the model repo
 - `model_dir` - Sub-directory of the model in the model folder 
+- `username` - (optional) Used for when git repo is private. This is the username associated with the private repo, when set the `token` field must also be set
+- `token` - (optional) Used for when git repo is private. This is the token associated with the user who is the owner of the private repo, when set the `username` field must also be set, [see info here](../../pipelines/README.md#git-repository-and-credentials)
 - `self_signed_cert` - (optional) path to a self signed cert to connect to access the repo
 
 These are all the fields in `s3_fetch`

--- a/test/e2e-tests/README.md
+++ b/test/e2e-tests/README.md
@@ -24,6 +24,8 @@ The structure of the `config.json` is in four sections, the top level fields, `g
 - `git_container_file_repo` - Git repo containing the container file
 - `git_container_file_revision` - Git branch in the container file repo
 - `container_relative_path` - Relative path from the root of the container file repo to where the container file is
+- `git_username` - (optional) Used for when the git repos containing the containerfile and model are private. This is the username associated with the private repo, when set the `git_token` field must also be set
+- `git_token` - (optional) Used for when the git repos containing the containerfile and model are private. This is the token associated with the user who is the owner of the private repo, when set the `git_username` field must also be set, [see info here](../../pipelines/README.md#git-repository-and-credentials)
 
 After the top level fields each sub object is used for a type of test. Setting `enabled` to `true` in each of these will tell the test suite to use those values in that object and to run those tests.
 
@@ -33,8 +35,6 @@ These are all the fields in `git_fetch`
 - `model_relative_path` - Relative path from the root of the model repo to where the model is 
 - `model_revision` - Branch of the model repo
 - `model_dir` - Sub-directory of the model in the model folder 
-- `username` - (optional) Used for when git repo is private. This is the username associated with the private repo, when set the `token` field must also be set
-- `token` - (optional) Used for when git repo is private. This is the token associated with the user who is the owner of the private repo, when set the `username` field must also be set, [see info here](../../pipelines/README.md#git-repository-and-credentials)
 - `self_signed_cert` - (optional) path to a self signed cert to connect to access the repo
 
 These are all the fields in `s3_fetch`

--- a/test/e2e-tests/support/config.go
+++ b/test/e2e-tests/support/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	GitContainerFileRepo     string   `json:"git_container_file_repo"`
 	GitContainerFileRevision string   `json:"git_container_file_revision"`
 	ContainerRelativePath    string   `json:"container_relative_path"`
+	GitUsername              string   `json:"git_username"`
+	GitToken                 string   `json:"git_token"`
 
 	GitFetchConfig GitFetchConfig `json:"git_fetch"`
 	S3FetchConfig  S3FetchConfig  `json:"s3_fetch"`
@@ -35,8 +37,6 @@ type GitFetchConfig struct {
 	ModelRelativePath string `json:"model_relative_path"`
 	ModelRevision     string `json:"model_revision"`
 	ModelDir          string `json:"model_dir"`
-	Username          string `json:"username"`
-	Token             string `json:"token"`
 	SelfSignedCert    string `json:"self_signed_cert"`
 }
 

--- a/test/e2e-tests/support/config.go
+++ b/test/e2e-tests/support/config.go
@@ -35,6 +35,8 @@ type GitFetchConfig struct {
 	ModelRelativePath string `json:"model_relative_path"`
 	ModelRevision     string `json:"model_revision"`
 	ModelDir          string `json:"model_dir"`
+	Username          string `json:"username"`
+	Token             string `json:"token"`
 	SelfSignedCert    string `json:"self_signed_cert"`
 }
 

--- a/test/e2e-tests/support/setup.go
+++ b/test/e2e-tests/support/setup.go
@@ -56,7 +56,7 @@ func RunSetup(ctx context.Context, config *Config) error {
 	}
 
 	// if git credentials are passed then create the secret
-	// needed as a workspace fot the pipelines
+	// needed as a workspace for the pipelines
 	if config.GitUsername != "" || config.GitToken != "" {
 		if config.GitToken == "" || config.GitUsername == "" {
 			return fmt.Errorf("both `git_username` and `git_token` must both be set when using git credentials")

--- a/test/e2e-tests/support/setup.go
+++ b/test/e2e-tests/support/setup.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
+	GitCredentialsTemplatePath           = "../../../examples/tekton/aiedge-e2e/templates/credentials-git.secret.yaml.template"
 	S3CredentialsTemplatePath            = "../../../examples/tekton/aiedge-e2e/templates/credentials-s3.secret.yaml.template"
 	ImageRegistryCredentialsTemplatePath = "../../../examples/tekton/aiedge-e2e/templates/credentials-image-registry.secret.yaml.template"
-	GitCredentialsTemplatePath           = "../../../examples/tekton/gitops-update-pipeline/templates/example-git-credentials-secret.yaml.template"
+	GitOpsCredentialsTemplatePath           = "../../../examples/tekton/gitops-update-pipeline/templates/example-git-credentials-secret.yaml.template"
 
 	SelfSignedCertTemplatePath = "../../../examples/tekton/aiedge-e2e/templates/self-signed-cert.configmap.yaml.template"
 
@@ -88,10 +89,33 @@ func RunSetup(ctx context.Context, config *Config) error {
 		}
 	}
 
-	// Git config has been set, load the credential template file
+	// Git fetch config has been set, load the credential template file
 	// and fill in the values in the config, then apply
 	if config.GitFetchConfig.Enabled {
 		bytes, err := os.ReadFile(GitCredentialsTemplatePath)
+		if err != nil {
+			return err
+		}
+
+		secret := applyconfigv1.SecretApplyConfiguration{}
+		err = yaml.Unmarshal(bytes, &secret)
+		if err != nil {
+			return err
+		}
+
+		secret.StringData["token"] = config.GitFetchConfig.Token
+		secret.StringData[".git-credentials"] = fmt.Sprintf("https://%v:%v@github.com", config.GitFetchConfig.Username, config.GitFetchConfig.Token)
+
+		_, err = config.Clients.Kubernetes.CoreV1().Secrets(config.Namespace).Apply(ctx, &secret, metav1.ApplyOptions{FieldManager: "Apply"})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Git ops config has been set, load the credential template file
+	// and fill in the values in the config, then apply
+	if config.GitOpsConfig.Enabled {
+		bytes, err := os.ReadFile(GitOpsCredentialsTemplatePath)
 		if err != nil {
 			return err
 		}

--- a/test/e2e-tests/support/tekton.go
+++ b/test/e2e-tests/support/tekton.go
@@ -17,6 +17,15 @@ func MountConfigMapAsWorkspaceToPipelineRun(configMapName string, workspaceName 
 	})
 }
 
+func MountSecretAsWorkspaceToPipelineRun(secretName string, workspaceName string, pipelineRun *pipelinev1.PipelineRun) {
+	pipelineRun.Spec.Workspaces = append(pipelineRun.Spec.Workspaces, pipelinev1.WorkspaceBinding{
+		Name: workspaceName,
+		Secret: &v1.SecretVolumeSource{
+			SecretName: secretName,
+		},
+	})
+}
+
 func SetPipelineRunParam(name string, value pipelinev1.ParamValue, pipelineRun *pipelinev1.PipelineRun) {
 	for index := range pipelineRun.Spec.Params {
 		param := &pipelineRun.Spec.Params[index]

--- a/test/e2e-tests/template.config.json
+++ b/test/e2e-tests/template.config.json
@@ -6,6 +6,8 @@
   "git_container_file_repo": "https://github.com/opendatahub-io/ai-edge.git",
   "git_container_file_revision": "main",
   "container_relative_path": "path/to/containerfile/containerfile.openvino.mlserver.mlflow",
+  "git_username": "",
+  "git_token": "",
 
   "git_fetch": {
     "enabled": true,
@@ -13,8 +15,6 @@
     "model_relative_path": "path/to/model",
     "model_revision": "main",
     "model_dir": "model_dir_name",
-    "username": "",
-    "token": "",
     "self_signed_cert": ""
   },
 

--- a/test/e2e-tests/template.config.json
+++ b/test/e2e-tests/template.config.json
@@ -13,6 +13,8 @@
     "model_relative_path": "path/to/model",
     "model_revision": "main",
     "model_dir": "model_dir_name",
+    "username": "",
+    "token": "",
     "self_signed_cert": ""
   },
 

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -58,6 +58,11 @@ func Test_S3Fetch_Pipeline(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	// validation on them both being set is done in setup
+	if config.GitToken != "" || config.GitUsername != "" {
+		support.MountSecretAsWorkspaceToPipelineRun("credentials-git", "git-basic-auth", &pipelineRun)
+	}
+
 	if config.S3FetchConfig.SelfSignedCert != "" {
 		support.MountConfigMapAsWorkspaceToPipelineRun("s3-self-signed-cert", "s3-ssl-cert", &pipelineRun)
 	}

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -102,6 +102,14 @@ func Test_GitFetch_Pipeline(t *testing.T) {
 		support.MountConfigMapAsWorkspaceToPipelineRun("git-self-signed-cert", "git-ssl-cert", &pipelineRun)
 	}
 
+	if config.GitFetchConfig.Token != "" || config.GitFetchConfig.Username != "" {
+		if !(config.GitFetchConfig.Token != "" && config.GitFetchConfig.Username != "") {
+			t.Fatal(fmt.Errorf("both `git_fetch.token` and `git_fetch.username` must be set when using git credentials"))
+		}
+
+		support.MountSecretAsWorkspaceToPipelineRun("credentials-git", "git-secret", &pipelineRun)
+	}
+
 	support.SetPipelineRunParam("target-image-tag-references", support.NewArrayParamValue(config.TargetImageTags), &pipelineRun)
 	support.SetPipelineRunParam("git-containerfile-repo", support.NewStringParamValue(config.GitContainerFileRepo), &pipelineRun)
 	support.SetPipelineRunParam("git-containerfile-revision", support.NewStringParamValue(config.GitContainerFileRevision), &pipelineRun)

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -102,12 +102,9 @@ func Test_GitFetch_Pipeline(t *testing.T) {
 		support.MountConfigMapAsWorkspaceToPipelineRun("git-self-signed-cert", "git-ssl-cert", &pipelineRun)
 	}
 
-	if config.GitFetchConfig.Token != "" || config.GitFetchConfig.Username != "" {
-		if config.GitFetchConfig.Token == "" || config.GitFetchConfig.Username == "" {
-			t.Fatal(fmt.Errorf("both `git_fetch.token` and `git_fetch.username` must be set when using git credentials"))
-		}
-
-		support.MountSecretAsWorkspaceToPipelineRun("credentials-git", "git-secret", &pipelineRun)
+	// validation on them both being set is done in setup
+	if config.GitToken != "" || config.GitUsername != "" {
+		support.MountSecretAsWorkspaceToPipelineRun("credentials-git", "git-basic-auth", &pipelineRun)
 	}
 
 	support.SetPipelineRunParam("target-image-tag-references", support.NewArrayParamValue(config.TargetImageTags), &pipelineRun)

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -103,7 +103,7 @@ func Test_GitFetch_Pipeline(t *testing.T) {
 	}
 
 	if config.GitFetchConfig.Token != "" || config.GitFetchConfig.Username != "" {
-		if !(config.GitFetchConfig.Token != "" && config.GitFetchConfig.Username != "") {
+		if config.GitFetchConfig.Token == "" || config.GitFetchConfig.Username == "" {
 			t.Fatal(fmt.Errorf("both `git_fetch.token` and `git_fetch.username` must be set when using git credentials"))
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

**This is blocked by https://github.com/opendatahub-io/ai-edge/pull/284**

Users can now fetch from private repos, this pr adds that ability to the aiedge-e2e pipeline but once #284 is merged these changes will be moved there. And with that any docs that are needed to give users info on the new feature.

The e2e tests have beed updated to support this optional feature and have been passing when using the `git_fetch` test when cloning from my own private repo.

## How Has This Been Tested?
- Using e2e tests fill in `token` and `username` in `config.json`
- All tests should pass

I have a private example repo if needed for testing confirmation

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
