### PR TITLE
RHOAIENG-209-Deprecate the use of Tekton ClusterTasks in any Pipelines

### DIFF
--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -382,14 +382,12 @@ spec:
   - name: skopeo-copy
     params:
     - name: SOURCE_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.source_image_url.path)
+      value: $(tasks.retrieve-build-image-info.source-image-url)
     - name: DESTINATION_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.destination_image_url.path)
+      value: $(tasks.retrieve-build-image-info.dest-image-url)
     - name: SRC_TLS_VERIFY
       value: "true"
     - name: DEST_TLS_VERIFY
-      value: "true"
-    - name: VERBOSE
       value: "true"
     runAfter:
     - retrieve-build-image-info

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -287,11 +287,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.1/task-openshift-client.yaml
     runAfter:
       - build-container-image
   - name: create-default-service
@@ -308,11 +308,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.1/task-openshift-client.yaml
   - name: test-model-rest-svc
     params:
     - name: service-name
@@ -349,11 +349,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.1/task-openshift-client.yaml
   - name: retrieve-build-image-info
     taskRef:
       kind: Task
@@ -382,12 +382,12 @@ spec:
   - name: skopeo-copy
     params:
     - name: SOURCE_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.source-image-url)
+      value: $(tasks.retrieve-build-image-info.results.source-image-url)
     - name: DESTINATION_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.dest-image-url)
-    - name: SRC_TLS_VERIFY
+      value: $(tasks.retrieve-build-image-info.results.dest-image-url)
+    - name: srcTLSverify
       value: "true"
-    - name: DEST_TLS_VERIFY
+    - name: destTLSverify
       value: "true"
     runAfter:
     - retrieve-build-image-info

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -377,7 +377,7 @@ spec:
     - test-model-rest-svc
     - stop-deployment
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
@@ -385,6 +385,10 @@ spec:
       value: ""
     - name: DESTINATION_IMAGE_URL
       value: ""
+    - name: SRC_TLS_VERIFY
+      value: "true"
+    - name: DEST_TLS_VERIFY
+      value: "true"
     runAfter:
     - retrieve-build-image-info
     taskRef:
@@ -397,7 +401,7 @@ spec:
         - name: pathInRepo
           value: tasks/task-skopeo-copy/0.4.2/task-skopeo-copy.yaml
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -381,15 +381,21 @@ spec:
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
-    - name: srcTLSverify
-      value: "true"
-    - name: destTLSverify
-      value: "true"
+    - name: SOURCE_IMAGE_URL
+      value: ""
+    - name: DESTINATION_IMAGE_URL
+      value: ""
     runAfter:
     - retrieve-build-image-info
     taskRef:
-      kind: ClusterTask
-      name: skopeo-copy
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
+        - name: revision
+          value: p
+        - name: pathInRepo
+          value: tasks/task-skopeo-copy/0.4.2/task-skopeo-copy.yaml
     workspaces:
     - name: images-url
       workspace: build-workspace-pv

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -287,11 +287,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.0/task-openshift-client.yaml
     runAfter:
       - build-container-image
   - name: create-default-service
@@ -308,11 +308,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.0/task-openshift-client.yaml
   - name: test-model-rest-svc
     params:
     - name: service-name
@@ -349,11 +349,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.0/task-openshift-client.yaml
   - name: retrieve-build-image-info
     taskRef:
       kind: Task
@@ -377,17 +377,19 @@ spec:
     - test-model-rest-svc
     - stop-deployment
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
     - name: SOURCE_IMAGE_URL
-      value: docker://docker.io/busybox:latest
+      value: $(tasks.retrieve-build-image-info.source_image_url.path)
     - name: DESTINATION_IMAGE_URL
-      value: docker://image-registry.openshift-image-registry.svc:5000/task-containers/busybox:latest
-    - name: srcTLSverify
+      value: $(tasks.retrieve-build-image-info.destination_image_url.path)
+    - name: SRC_TLS_VERIFY
       value: "true"
-    - name: destTLSverify
+    - name: DEST_TLS_VERIFY
+      value: "true"
+    - name: VERBOSE
       value: "true"
     runAfter:
     - retrieve-build-image-info
@@ -401,7 +403,7 @@ spec:
         - name: namespace
           value: openshift-pipelines
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -108,8 +108,14 @@ spec:
   tasks:
   - name: fetch-model-git
     taskRef:
-      kind: ClusterTask
-      name: git-clone
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/git-clone/0.9/git-clone.yaml
     params:
     - name: url
       value: $(params.git-model-repo)
@@ -141,6 +147,15 @@ spec:
     - name: workspace
       workspace: build-workspace-pv
   - name: git-clone-containerfile-repo
+    taskRef:
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/git-clone/0.9/git-clone.yaml  
     params:
     - name: url
       value: $(params.git-containerfile-repo)
@@ -150,9 +165,6 @@ spec:
       value: /containerfile_repo/
     runAfter:
     - move-model-to-root-dir
-    taskRef:
-      kind: ClusterTask
-      name: git-clone
     workspaces:
     - name: output
       workspace: build-workspace-pv
@@ -264,8 +276,14 @@ spec:
         oc wait deployment -n $(params.target-namespace) $(tasks.sanitise-model-name.results.output-string)-$(params.model-version) --for condition=Available=True --timeout=120s
         oc wait pod -n $(params.target-namespace) -l app=$(params.model-name)-$(params.model-version) --for condition=Ready=True --timeout=120s
     taskRef:
-      kind: ClusterTask
-      name: openshift-client
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/openshift-client/0.2/openshift-client.yaml
     runAfter:
       - build-container-image
   - name: create-default-service
@@ -279,8 +297,14 @@ spec:
     runAfter:
     - test-container-deploy
     taskRef:
-      kind: ClusterTask
-      name: openshift-client
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/openshift-client/0.2/openshift-client.yaml
   - name: test-model-rest-svc
     params:
     - name: service-name
@@ -314,8 +338,14 @@ spec:
     runAfter:
     - test-model-rest-svc
     taskRef:
-      kind: ClusterTask
-      name: openshift-client
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/openshift-client/0.2/openshift-client.yaml
   - name: retrieve-build-image-info
     taskRef:
       kind: Task
@@ -350,8 +380,14 @@ spec:
     runAfter:
     - retrieve-build-image-info
     taskRef:
-      kind: ClusterTask
-      name: skopeo-copy
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/skopeo-copy/0.3/skopeo-copy.yaml
     workspaces:
     - name: images-url
       workspace: build-workspace-pv

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -287,11 +287,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/openshift-pipelines/tektoncd-catalog
+          value: https://github.com/tektoncd/catalog.git
         - name: revision
-          value: p
+          value: main
         - name: pathInRepo
-          value: tasks/task-openshift-client/0.2.0/task-openshift-client.yaml
+          value: task/openshift-client/0.2/openshift-client.yaml
     runAfter:
       - build-container-image
   - name: create-default-service
@@ -308,11 +308,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/openshift-pipelines/tektoncd-catalog
+          value: https://github.com/tektoncd/catalog.git
         - name: revision
-          value: p
+          value: main
         - name: pathInRepo
-          value: tasks/task-openshift-client/0.2.0/task-openshift-client.yaml
+          value: task/openshift-client/0.2/openshift-client.yaml
   - name: test-model-rest-svc
     params:
     - name: service-name
@@ -349,11 +349,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/openshift-pipelines/tektoncd-catalog
+          value: https://github.com/tektoncd/catalog.git
         - name: revision
-          value: p
+          value: main
         - name: pathInRepo
-          value: tasks/task-openshift-client/0.2.0/task-openshift-client.yaml
+          value: task/openshift-client/0.2/openshift-client.yaml
   - name: retrieve-build-image-info
     taskRef:
       kind: Task

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -381,10 +381,6 @@ spec:
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
-    - name: SOURCE_IMAGE_URL
-      value: ""
-    - name: DESTINATION_IMAGE_URL
-      value: ""
     - name: SRC_TLS_VERIFY
       value: "true"
     - name: DEST_TLS_VERIFY

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -56,22 +56,22 @@ spec:
   results:
   - name: git-model-fetched-commit
     description: The commit hash of the git repo where the model files were fetched from
-    value: $(tasks.fetch-model-git.results.commit)
+    value: $(tasks.fetch-model-git.results.COMMIT)
   - name: git-model-fetched-url
     description: The url of the git repo where the model files were fetched from
-    value: $(tasks.fetch-model-git.results.url)
+    value: $(tasks.fetch-model-git.results.URL)
   - name: git-model-fetched-commit-epoch
     description: The commit timestamp of the git repo where the model files were fetched from
-    value: $(tasks.fetch-model-git.results.committer-date)
+    value: $(tasks.fetch-model-git.results.COMMITTER_DATE)
   - name: git-containerfile-fetched-commit
     description: The commit hash of the git repo where the containerfile was fetched from
-    value: $(tasks.git-clone-containerfile-repo.results.commit)
+    value: $(tasks.git-clone-containerfile-repo.results.COMMIT)
   - name: git-containerfile-fetched-url
     description: The url of the git repo where the containerfile was fetched from
-    value: $(tasks.git-clone-containerfile-repo.results.url)
+    value: $(tasks.git-clone-containerfile-repo.results.URL)
   - name: git-containerfile-fetched-commit-epoch
     description: The commit timestamp of the git repo where the containerfile was fetched from
-    value: $(tasks.git-clone-containerfile-repo.results.committer-date)
+    value: $(tasks.git-clone-containerfile-repo.results.COMMITTER_DATE)
   - name: model-files-size
     description: The size of the model files
     value: $(tasks.check-model-and-containerfile-exists.results.model-files-size)
@@ -108,20 +108,20 @@ spec:
   tasks:
   - name: fetch-model-git
     taskRef:
-      resolver: git
+      resolver: cluster
       params:
-        - name: url
-          value: https://github.com/tektoncd/catalog.git
-        - name: revision
-          value: main
-        - name: pathInRepo
-          value: task/git-clone/0.9/git-clone.yaml
+        - name: kind
+          value: task
+        - name: name
+          value: git-clone
+        - name: namespace
+          value: openshift-pipelines
     params:
-    - name: url
+    - name: URL
       value: $(params.git-model-repo)
-    - name: revision
+    - name: REVISION
       value: $(params.git-model-revision)
-    - name: subdirectory
+    - name: SUBDIRECTORY
       value: /model_dir-$(params.model-name)/
     workspaces:
     - name: output
@@ -148,20 +148,20 @@ spec:
       workspace: build-workspace-pv
   - name: git-clone-containerfile-repo
     taskRef:
-      resolver: git
+      resolver: cluster
       params:
-        - name: url
-          value: https://github.com/tektoncd/catalog.git
-        - name: revision
-          value: main
-        - name: pathInRepo
-          value: task/git-clone/0.9/git-clone.yaml  
+        - name: kind
+          value: task
+        - name: name
+          value: git-clone
+        - name: namespace
+          value: openshift-pipelines
     params:
-    - name: url
+    - name: URL
       value: $(params.git-containerfile-repo)
-    - name: revision
+    - name: REVISION
       value: $(params.git-containerfile-revision)
-    - name: subdirectory
+    - name: SUBDIRECTORY
       value: /containerfile_repo/
     runAfter:
     - move-model-to-root-dir
@@ -218,13 +218,21 @@ spec:
     runAfter:
     - sanitise-model-name
     taskRef:
-      kind: ClusterTask
-      name: buildah
+      resolver: cluster
+      params:
+        - name: kind
+          value: task
+        - name: name
+          value: buildah
+        - name: namespace
+          value: openshift-pipelines
     workspaces:
     - name: source
       workspace: build-workspace-pv
   - name: test-container-deploy
     params:
+    - name: VERSION
+      value: latest
     - name: SCRIPT
       value: |
         cat <<EOF | oc apply -f -
@@ -373,6 +381,10 @@ spec:
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
+    - name: SOURCE_IMAGE_URL
+      value: docker://docker.io/busybox:latest
+    - name: DESTINATION_IMAGE_URL
+      value: docker://image-registry.openshift-image-registry.svc:5000/task-containers/busybox:latest
     - name: srcTLSverify
       value: "true"
     - name: destTLSverify
@@ -380,14 +392,14 @@ spec:
     runAfter:
     - retrieve-build-image-info
     taskRef:
-      resolver: git
+      resolver: cluster
       params:
-        - name: url
-          value: https://github.com/tektoncd/catalog.git
-        - name: revision
-          value: main
-        - name: pathInRepo
-          value: task/skopeo-copy/0.3/skopeo-copy.yaml
+        - name: kind
+          value: task
+        - name: name
+          value: skopeo-copy
+        - name: namespace
+          value: openshift-pipelines
     workspaces:
     - name: images-url
       workspace: build-workspace-pv

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -377,14 +377,10 @@ spec:
     - test-model-rest-svc
     - stop-deployment
     workspaces:
-    - name: images_url
+    - name: images-url
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
-    - name: SOURCE_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.results.source-image-url)
-    - name: DESTINATION_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.results.dest-image-url)
     - name: srcTLSverify
       value: "true"
     - name: destTLSverify
@@ -392,16 +388,10 @@ spec:
     runAfter:
     - retrieve-build-image-info
     taskRef:
-      resolver: cluster
-      params:
-        - name: kind
-          value: task
-        - name: name
-          value: skopeo-copy
-        - name: namespace
-          value: openshift-pipelines
+      kind: ClusterTask
+      name: skopeo-copy
     workspaces:
-    - name: images_url
+    - name: images-url
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -350,15 +350,21 @@ spec:
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
-    - name: srcTLSverify
-      value: "true"
-    - name: destTLSverify
-      value: "true"
+    - name: SOURCE_IMAGE_URL
+      value: ""
+    - name: DESTINATION_IMAGE_URL
+      value: ""
     runAfter:
     - retrieve-build-image-info
     taskRef:
-      kind: ClusterTask
-      name: skopeo-copy
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
+        - name: revision
+          value: p
+        - name: pathInRepo
+          value: tasks/task-skopeo-copy/0.4.2/task-skopeo-copy.yaml
     workspaces:
     - name: images-url
       workspace: build-workspace-pv

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -55,13 +55,13 @@ spec:
     value: $(tasks.fetch-model-s3.results.s3-url)
   - name: git-containerfile-fetched-commit
     description: The commit hash of the git repo where the containerfile was fetched from
-    value: $(tasks.git-clone-containerfile-repo.results.commit)
+    value: $(tasks.git-clone-containerfile-repo.results.COMMIT)
   - name: git-containerfile-fetched-url
     description: The url of the git repo where the containerfile was fetched from
-    value: $(tasks.git-clone-containerfile-repo.results.url)
+    value: $(tasks.git-clone-containerfile-repo.results.URL)
   - name: git-containerfile-fetched-commit-epoch
     description: The commit timestamp of the git repo where the containerfile was fetched from
-    value: $(tasks.git-clone-containerfile-repo.results.committer-date)
+    value: $(tasks.git-clone-containerfile-repo.results.COMMITTER_DATE)
   - name: model-files-size
     description: The size of the model files
     value: $(tasks.check-model-and-containerfile-exists.results.model-files-size)
@@ -116,18 +116,24 @@ spec:
     - name: ssl-ca-directory
       workspace: s3-ssl-cert
   - name: git-clone-containerfile-repo
+    taskRef:
+      resolver: cluster
+      params:
+        - name: kind
+          value: task
+        - name: name
+          value: git-clone
+        - name: namespace
+          value: openshift-pipelines
     params:
-    - name: url
+    - name: URL
       value: $(params.git-containerfile-repo)
-    - name: revision
+    - name: REVISION
       value: $(params.git-containerfile-revision)
-    - name: subdirectory
+    - name: SUBDIRECTORY
       value: /containerfile_repo/
     runAfter:
     - fetch-model-s3
-    taskRef:
-      kind: ClusterTask
-      name: git-clone
     workspaces:
     - name: output
       workspace: build-workspace-pv
@@ -181,13 +187,21 @@ spec:
     runAfter:
     - sanitise-model-name
     taskRef:
-      kind: ClusterTask
-      name: buildah
+      resolver: cluster
+      params:
+        - name: kind
+          value: task
+        - name: name
+          value: buildah
+        - name: namespace
+          value: openshift-pipelines
     workspaces:
     - name: source
       workspace: build-workspace-pv
   - name: test-container-deploy
     params:
+    - name: VERSION
+      value: latest
     - name: SCRIPT
       value: |
         cat <<EOF | oc apply -f -
@@ -239,8 +253,14 @@ spec:
         oc wait deployment -n $(params.target-namespace) $(tasks.sanitise-model-name.results.output-string)-$(params.model-version) --for condition=Available=True --timeout=120s
         oc wait pod -n $(params.target-namespace) -l app=$(params.model-name)-$(params.model-version) --for condition=Ready=True --timeout=120s
     taskRef:
-      kind: ClusterTask
-      name: openshift-client
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/openshift-client/0.2/openshift-client.yaml
     runAfter:
       - build-container-image
   - name: create-default-service
@@ -254,8 +274,14 @@ spec:
     runAfter:
     - test-container-deploy
     taskRef:
-      kind: ClusterTask
-      name: openshift-client
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/openshift-client/0.2/openshift-client.yaml
   - name: test-model-rest-svc
     params:
     - name: service-name
@@ -289,8 +315,14 @@ spec:
     runAfter:
     - test-model-rest-svc
     taskRef:
-      kind: ClusterTask
-      name: openshift-client
+      resolver: git
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: task/openshift-client/0.2/openshift-client.yaml
   - name: retrieve-build-image-info
     taskRef:
       kind: Task
@@ -318,6 +350,10 @@ spec:
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
+    - name: SOURCE_IMAGE_URL
+      value: docker://docker.io/busybox:latest
+    - name: DESTINATION_IMAGE_URL
+      value: docker://image-registry.openshift-image-registry.svc:5000/task-containers/busybox:latest
     - name: srcTLSverify
       value: "true"
     - name: destTLSverify
@@ -325,8 +361,14 @@ spec:
     runAfter:
     - retrieve-build-image-info
     taskRef:
-      kind: ClusterTask
-      name: skopeo-copy
+      resolver: cluster
+      params:
+        - name: kind
+          value: task
+        - name: name
+          value: skopeo-copy
+        - name: namespace
+          value: openshift-pipelines
     workspaces:
     - name: images-url
       workspace: build-workspace-pv

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -346,7 +346,7 @@ spec:
     - test-model-rest-svc
     - stop-deployment
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
@@ -354,6 +354,10 @@ spec:
       value: ""
     - name: DESTINATION_IMAGE_URL
       value: ""
+    - name: SRC_TLS_VERIFY
+      value: "true"
+    - name: DEST_TLS_VERIFY
+      value: "true"
     runAfter:
     - retrieve-build-image-info
     taskRef:
@@ -366,7 +370,7 @@ spec:
         - name: pathInRepo
           value: tasks/task-skopeo-copy/0.4.2/task-skopeo-copy.yaml
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -351,12 +351,14 @@ spec:
   - name: skopeo-copy
     params:
     - name: SOURCE_IMAGE_URL
-      value: docker://docker.io/busybox:latest
+      value: $(tasks.retrieve-build-image-info.source_image_url.path)
     - name: DESTINATION_IMAGE_URL
-      value: docker://image-registry.openshift-image-registry.svc:5000/task-containers/busybox:latest
-    - name: srcTLSverify
+      value: $(tasks.retrieve-build-image-info.destination_image_url.path)
+    - name: SRC_TLS_VERIFY
       value: "true"
-    - name: destTLSverify
+    - name: DEST_TLS_VERIFY
+      value: "true"
+    - name: VERBOSE
       value: "true"
     runAfter:
     - retrieve-build-image-info
@@ -370,7 +372,7 @@ spec:
         - name: namespace
           value: openshift-pipelines
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -346,7 +346,7 @@ spec:
     - test-model-rest-svc
     - stop-deployment
     workspaces:
-    - name: images-url
+    - name: images_url
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -351,14 +351,12 @@ spec:
   - name: skopeo-copy
     params:
     - name: SOURCE_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.source_image_url.path)
+      value: $(tasks.retrieve-build-image-info.source-image-url)
     - name: DESTINATION_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.destination_image_url.path)
+      value: $(tasks.retrieve-build-image-info.dest-image-url)
     - name: SRC_TLS_VERIFY
       value: "true"
     - name: DEST_TLS_VERIFY
-      value: "true"
-    - name: VERBOSE
       value: "true"
     runAfter:
     - retrieve-build-image-info

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -350,10 +350,6 @@ spec:
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
-    - name: SOURCE_IMAGE_URL
-      value: ""
-    - name: DESTINATION_IMAGE_URL
-      value: ""
     - name: SRC_TLS_VERIFY
       value: "true"
     - name: DEST_TLS_VERIFY

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -256,11 +256,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.1/task-openshift-client.yaml
     runAfter:
       - build-container-image
   - name: create-default-service
@@ -277,11 +277,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.1/task-openshift-client.yaml
   - name: test-model-rest-svc
     params:
     - name: service-name
@@ -318,11 +318,11 @@ spec:
       resolver: git
       params:
         - name: url
-          value: https://github.com/tektoncd/catalog.git
+          value: https://github.com/openshift-pipelines/tektoncd-catalog
         - name: revision
-          value: main
+          value: p
         - name: pathInRepo
-          value: task/openshift-client/0.2/openshift-client.yaml
+          value: tasks/task-openshift-client/0.2.1/task-openshift-client.yaml
   - name: retrieve-build-image-info
     taskRef:
       kind: Task
@@ -351,12 +351,12 @@ spec:
   - name: skopeo-copy
     params:
     - name: SOURCE_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.source-image-url)
+      value: $(tasks.retrieve-build-image-info.results.source-image-url)
     - name: DESTINATION_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.dest-image-url)
-    - name: SRC_TLS_VERIFY
+      value: $(tasks.retrieve-build-image-info.results.dest-image-url)
+    - name: srcTLSverify
       value: "true"
-    - name: DEST_TLS_VERIFY
+    - name: destTLSverify
       value: "true"
     runAfter:
     - retrieve-build-image-info

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -346,14 +346,10 @@ spec:
     - test-model-rest-svc
     - stop-deployment
     workspaces:
-    - name: images_url
+    - name: images-url
       workspace: build-workspace-pv
   - name: skopeo-copy
     params:
-    - name: SOURCE_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.results.source-image-url)
-    - name: DESTINATION_IMAGE_URL
-      value: $(tasks.retrieve-build-image-info.results.dest-image-url)
     - name: srcTLSverify
       value: "true"
     - name: destTLSverify
@@ -361,16 +357,10 @@ spec:
     runAfter:
     - retrieve-build-image-info
     taskRef:
-      resolver: cluster
-      params:
-        - name: kind
-          value: task
-        - name: name
-          value: skopeo-copy
-        - name: namespace
-          value: openshift-pipelines
+      kind: ClusterTask
+      name: skopeo-copy
     workspaces:
-    - name: images_url
+    - name: images-url
       workspace: build-workspace-pv
   workspaces:
   - name: build-workspace-pv

--- a/manifests/tasks/retrieve-build-image-info/README.md
+++ b/manifests/tasks/retrieve-build-image-info/README.md
@@ -22,5 +22,3 @@ This task returns more detailed info about a model that has just been built and 
 * **buildah-version**: The version of buildah used to build the image
 * **image-digest-reference**: The fully qualified image digest reference of the image
 * **target-image-tag-references**: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)
-* **source-image-url**: The source image URL that was inspected
-* **dest-image-url**: The destination image URL where the image will be pushed

--- a/manifests/tasks/retrieve-build-image-info/README.md
+++ b/manifests/tasks/retrieve-build-image-info/README.md
@@ -1,6 +1,6 @@
 # `retrieve-build-image-info`
 
-This task returns more detailed info about a model that has just been built and builds a url.txt file with all image tags to be pushed to
+This task returns more detailed info about a model that has just been built and sets the results all image tags to be pushed to
 
 ## Parameters
 * **namespace**: The namespace where the model was built
@@ -12,7 +12,7 @@ This task returns more detailed info about a model that has just been built and 
 * **target-image-tag-references**: The image tag references used for the final built image
 
 ## Workspaces
-* **images-url**: workspace where url.txt file is created
+* **images_url**: workspace where url.txt file is created
 
 ## Results
 * **model-name**: The name of the model
@@ -22,3 +22,5 @@ This task returns more detailed info about a model that has just been built and 
 * **buildah-version**: The version of buildah used to build the image
 * **image-digest-reference**: The fully qualified image digest reference of the image
 * **target-image-tag-references**: The fully qualified image reference that the image was pushed to (e.g. registry.example.com/my-org/ai-model:1.0-1)
+* **source-image-url**: The source image URL that was inspected
+* **dest-image-url**: The destination image URL where the image will be pushed

--- a/manifests/tasks/retrieve-build-image-info/README.md
+++ b/manifests/tasks/retrieve-build-image-info/README.md
@@ -12,7 +12,7 @@ This task returns more detailed info about a model that has just been built and 
 * **target-image-tag-references**: The image tag references used for the final built image
 
 ## Workspaces
-* **images-url**: workspace where url.txt file is created
+* **images_url**: workspace where url.txt file is created
 
 ## Results
 * **model-name**: The name of the model

--- a/manifests/tasks/retrieve-build-image-info/README.md
+++ b/manifests/tasks/retrieve-build-image-info/README.md
@@ -1,6 +1,6 @@
 # `retrieve-build-image-info`
 
-This task returns more detailed info about a model that has just been built and sets the results all image tags to be pushed to
+This task returns more detailed info about a model that has just been built and builds a url.txt file with all image tags to be pushed to
 
 ## Parameters
 * **namespace**: The namespace where the model was built
@@ -12,7 +12,7 @@ This task returns more detailed info about a model that has just been built and 
 * **target-image-tag-references**: The image tag references used for the final built image
 
 ## Workspaces
-* **images_url**: workspace where url.txt file is created
+* **images-url**: workspace where url.txt file is created
 
 ## Results
 * **model-name**: The name of the model

--- a/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
+++ b/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   description: This task returns more detailed info about a model that has just been built and builds a url.txt file with all image tags to be pushed to
   workspaces:
-  - name: images_url
+  - name: images-url
     description: workspace where url.txt file is created
   params:
   - name: namespace
@@ -57,23 +57,28 @@ spec:
       skopeo inspect --format '{{index .Labels "io.buildah.version"}}' docker://$DOCKER_IMAGE_REF | tee $(results.buildah-version.path) ;
       echo ;
       echo -n "$@" | tee $(results.target-image-tag-references.path) ;
-      echo ;
-      # Set source and destination image URLs in results
-      export SOURCE_IMAGE_URL="docker://${DOCKER_IMAGE_REF}"
-      export DEST_IMAGE_URLS=""
-      for target in "$2"; do
-        DEST_IMAGE_URLS="${DEST_IMAGE_URLS} docker://${target}"
-      done
-      echo ;
-      echo -n $SOURCE_IMAGE_URL | tee $(results.source-image-url.path) ;
-      echo ;
-      echo -n $DEST_IMAGE_URLS | tee $(results.dest-image-url.path) ;
+  - name: build-urls-txt
+    image: registry.access.redhat.com/ubi9/ubi-micro
+    args:
+      - "$(params.target-image-tag-references[*])"
+    script: |
+      #!/usr/bin/env bash
 
+      set -Eeuo pipefail
+
+      # The skopeo-copy task looks for this file in its workspace if the source and destination parameters are
+      # empty. This is what allows pushing to more than one tag from the single taskrun.
+      export URLTXT=$(workspaces.images-url.path)/url.txt
+      export SOURCE_IMAGE_REF=$(cat $(results.image-digest-reference.path))
+
+      rm -f ${URLTXT}
+      for target in "$@"; do
+        echo "docker://${SOURCE_IMAGE_REF} docker://${target}" >> "${URLTXT}"
+      done
+
+      echo "Contents of ${URLTXT}:"
+      cat ${URLTXT}
   results:
-  - name: source-image-url
-    description: The source image URL that was inspected 
-  - name: dest-image-url
-    description: The destination image URL(s) where the image will be pushed
   - name: model-name
     description: The name of the model
   - name: model-version

--- a/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
+++ b/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
@@ -27,7 +27,7 @@ spec:
     type: array
     description: The image tag references used for the final built image
   workspaces:
-  - name: images-url
+  - name: images_url
     description: workspace where url.txt file is created
   steps:
   - name: get-image-sha
@@ -57,28 +57,19 @@ spec:
       skopeo inspect --format '{{index .Labels "io.buildah.version"}}' docker://$DOCKER_IMAGE_REF | tee $(results.buildah-version.path) ;
       echo ;
       echo -n "$@" | tee $(results.target-image-tag-references.path) ;
-  - name: build-urls-txt
-    image: registry.access.redhat.com/ubi9/ubi-micro
-    args:
-      - "$(params.target-image-tag-references[*])"
-    script: |
-      #!/usr/bin/env bash
+      
+      export source_image_url=$(cat $(results.image-digest-reference.path))
+      export destination_image_url=""
 
-      set -Eeuo pipefail
-
-      # The skopeo-copy task looks for this file in its workspace if the source and destination parameters are
-      # empty. This is what allows pushing to more than one tag from the single taskrun.
-      export URLTXT=$(workspaces.images-url.path)/url.txt
-      export SOURCE_IMAGE_REF=$(cat $(results.image-digest-reference.path))
-
-      rm -f ${URLTXT}
       for target in "$@"; do
-        echo "docker://${SOURCE_IMAGE_REF} docker://${target}" >> "${URLTXT}"
+        destination_image_url="docker://${target}"
       done
 
-      echo "Contents of ${URLTXT}:"
-      cat ${URLTXT}
   results:
+  - name: source_image_url
+    description: URL of the image to be copied to the destination registry
+  - name: destination_image_url
+    description: URL of the image where the image from source should be copied to
   - name: model-name
     description: The name of the model
   - name: model-version

--- a/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
+++ b/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   description: This task returns more detailed info about a model that has just been built and builds a url.txt file with all image tags to be pushed to
   workspaces:
-  - name: images-url
+  - name: images_url
     description: workspace where url.txt file is created
   params:
   - name: namespace
@@ -68,7 +68,7 @@ spec:
 
       # The skopeo-copy task looks for this file in its workspace if the source and destination parameters are
       # empty. This is what allows pushing to more than one tag from the single taskrun.
-      export URLTXT=$(workspaces.images-url.path)/url.txt
+      export URLTXT=$(workspaces.images_url.path)/url.txt
       export SOURCE_IMAGE_REF=$(cat $(results.image-digest-reference.path))
 
       rm -f ${URLTXT}

--- a/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
+++ b/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
@@ -4,6 +4,9 @@ metadata:
   name: retrieve-build-image-info
 spec:
   description: This task returns more detailed info about a model that has just been built and builds a url.txt file with all image tags to be pushed to
+  workspaces:
+  - name: images_url
+    description: workspace where url.txt file is created
   params:
   - name: namespace
     type: string
@@ -26,9 +29,6 @@ spec:
   - name: target-image-tag-references
     type: array
     description: The image tag references used for the final built image
-  workspaces:
-  - name: images_url
-    description: workspace where url.txt file is created
   steps:
   - name: get-image-sha
     image: registry.access.redhat.com/ubi9/skopeo
@@ -58,18 +58,22 @@ spec:
       echo ;
       echo -n "$@" | tee $(results.target-image-tag-references.path) ;
       
-      export source_image_url=$(cat $(results.image-digest-reference.path))
-      export destination_image_url=""
-
+      # Set source and destination image URLs in results
+      export SOURCE_IMAGE_URL=$DOCKER_IMAGE_REF
+      export DEST_IMAGE_URLS=""
       for target in "$@"; do
-        destination_image_url="docker://${target}"
+        DEST_IMAGE_URLS="${DEST_IMAGE_URLS} docker://${target}"
       done
 
+      echo -n $SOURCE_IMAGE_URL | tee $(results.source-image-url.path) ;
+      echo ;
+      echo -n $DEST_IMAGE_URLS | tee $(results.dest-image-url.path) ;
+
   results:
-  - name: source_image_url
-    description: URL of the image to be copied to the destination registry
-  - name: destination_image_url
-    description: URL of the image where the image from source should be copied to
+  - name: source-image-url
+    description: The source image URL that was inspected 
+  - name: dest-image-url
+    description: The destination image URL(s) where the image will be pushed
   - name: model-name
     description: The name of the model
   - name: model-version

--- a/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
+++ b/manifests/tasks/retrieve-build-image-info/retrieve-build-image-info.yaml
@@ -57,14 +57,14 @@ spec:
       skopeo inspect --format '{{index .Labels "io.buildah.version"}}' docker://$DOCKER_IMAGE_REF | tee $(results.buildah-version.path) ;
       echo ;
       echo -n "$@" | tee $(results.target-image-tag-references.path) ;
-      
+      echo ;
       # Set source and destination image URLs in results
-      export SOURCE_IMAGE_URL=$DOCKER_IMAGE_REF
+      export SOURCE_IMAGE_URL="docker://${DOCKER_IMAGE_REF}"
       export DEST_IMAGE_URLS=""
-      for target in "$@"; do
+      for target in "$2"; do
         DEST_IMAGE_URLS="${DEST_IMAGE_URLS} docker://${target}"
       done
-
+      echo ;
       echo -n $SOURCE_IMAGE_URL | tee $(results.source-image-url.path) ;
       echo ;
       echo -n $DEST_IMAGE_URLS | tee $(results.dest-image-url.path) ;

--- a/test/e2e-tests/tests/pipelines_test.go
+++ b/test/e2e-tests/tests/pipelines_test.go
@@ -304,6 +304,8 @@ func WaitForAllPipelineRunsToComplete(ctx context.Context, pipelineRunName strin
 				return true, nil
 			case "Succeeded":
 				return true, nil
+			case "ResolvingTaskRef":
+				return false, nil
 			default:
 				panic(fmt.Sprintf("unknown status condition while waiting for \"%v\" pipeline run to finish: %v", pipelineRunName, condition.Reason))
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
JIRA: [RHOAIENG-209](https://issues.redhat.com/browse/RHOAIENG-209)
## Description
<!--- Describe your changes in detail -->
Deprecating clustertasks and replacing with git-resolvers. The idea is we can currently pulling in pre-defined task yamls from the tekton catalog git repo. Ref: [Migration from clustertasks to tekton-resolvers ](https://www.redhat.com/en/blog/migration-from-clustertasks-to-tekton-resolvers-in-openshift-pipelines)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
oc apply -k manifests/
oc create -f examples/tekton/aiedge-e2e/example-pipelineruns/git-fetch.tensorflow-housing.pipelinerun.yaml
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
