### PR TITLE
Increase timeout for the s3-fetch pipeline with bike-rentals

### DIFF
--- a/test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh
+++ b/test/shell-pipeline-tests/seldon-bike-rentals/pipelines-test-seldon-bike-rentals.sh
@@ -56,7 +56,7 @@ if [[ $PIPELINE_RUN_NAME == "" ]]; then
 fi
 
 ## wait for the result
-waitForOpResult 200 "True" "False" "oc get pipelinerun $PIPELINE_RUN_NAME -o jsonpath={.status.conditions[?\(@.type==\'Succeeded\'\)].status}"
+waitForOpResult 220 "True" "False" "oc get pipelinerun $PIPELINE_RUN_NAME -o jsonpath={.status.conditions[?\(@.type==\'Succeeded\'\)].status}"
 PIPELINE_RUN_RESULT=$?
 
 saveArtifacts "$PIPELINE_RUN_NAME"


### PR DESCRIPTION
## Description
Periodic job finishes with 190-194 tries out of 200 which means there is not enough room in case the environment is slower, leading to false negatives. Therefore, I am raising it to 220. Other pipelines are OK.

## How Has This Been Tested?
Not needed.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
