### PR TITLE
Fix ArgoCD sync of OTel collector

### DIFF
--- a/acm/odh-edge/apps/telemetry/otel-collector.yaml
+++ b/acm/odh-edge/apps/telemetry/otel-collector.yaml
@@ -15,19 +15,21 @@ spec:
       prometheus:
         config:
           scrape_configs:
-            - job_name: 'otel-collector'
-              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              job_name: otel-collector
+              metrics_path: /metrics
               scrape_interval: 5s
-              metrics_path: "/metrics"
               static_configs:
-                - targets: ['tensorflow-housing-app-model-1.tensorflow-housing-app.svc.cluster.local:8080', 'bike-rental-app-model-1.bike-rental-app.svc.cluster.local:8082']
-    processors:
+                - targets:
+                    - tensorflow-housing-app-model-1.tensorflow-housing-app.svc.cluster.local:8080
+                    - bike-rental-app-model-1.bike-rental-app.svc.cluster.local:8082
     exporters:
       prometheus:
-        endpoint: "0.0.0.0:8889"
+        endpoint: 0.0.0.0:8889
     service:
       pipelines:
         metrics:
-          receivers: [prometheus]
-          processors: []
-          exporters: [prometheus]
+          exporters:
+            - prometheus
+          receivers:
+            - prometheus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Before this change, it would never get to a fully synced state in ArgoCD because it sees a diff between the live state versus the desired state of the manifest.

### Before
![Screenshot from 2024-10-09 17-55-45](https://github.com/user-attachments/assets/260dd5b1-e136-496d-b411-666d5d1b4576)

### After
![image](https://github.com/user-attachments/assets/d6ff616c-0588-4ba7-85cd-f8bf04301bed)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See screenshots above: it was tested by verifying that the issue no longer occurs after the change.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
