### PR TITLE
Fix bike-rental-app image

### DIFF
--- a/acm/odh-edge/apps/bike-rental-app/kustomization.yaml
+++ b/acm/odh-edge/apps/bike-rental-app/kustomization.yaml
@@ -64,4 +64,4 @@ replacements:
 images:
   - name: edge-model-template-image
     newName: quay.io/rhoai-edge/bike-rentals-auto-ml
-    digest: sha256:c4d68d1de1d90f52cb4053d0655496c3a677c55821db21492908a9584dd2e93b
+    digest: sha256:ed53c9566f8424e84ee4be1fd51939f99c1406a0ceb8b4d0b72693e33faea7aa


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It seems like the old manifest was deleted from quay.io. It probably didn't have a tag referring to it. This updates to the latest tagged image, and shouldn't get untagged.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I pointed my config to the source branch of this PR, and I can see that the image is rolled out successfully and is healthy:

![image](https://github.com/user-attachments/assets/49fb3864-a335-462d-967f-b1b8035ea716)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
