### PR TITLE
Increase timout for waiting for deployment and pods

### DIFF
--- a/examples/models/bike-rentals-auto-ml/conda.yaml
+++ b/examples/models/bike-rentals-auto-ml/conda.yaml
@@ -116,6 +116,7 @@ dependencies:
   - ml-wrappers==0.4.7
   - mlflow==2.14.3
   - mlflow-skinny==2.14.3
+  - mlserver==1.4.0
   - mlserver-mlflow==1.4.0
   - mltable==1.3.0
   - msal==1.21.0

--- a/examples/models/bike-rentals-auto-ml/requirements.txt
+++ b/examples/models/bike-rentals-auto-ml/requirements.txt
@@ -110,6 +110,7 @@ matplotlib-inline==0.1.6
 ml-wrappers==0.4.7
 mlflow==2.14.3
 mlflow-skinny==2.14.3
+mlserver==1.4.0
 mlserver-mlflow==1.4.0
 mltable==1.3.0
 msal==1.21.0

--- a/manifests/pipelines/git-fetch-pipeline.yaml
+++ b/manifests/pipelines/git-fetch-pipeline.yaml
@@ -281,8 +281,8 @@ spec:
                 resources: {}
         status: {}
         EOF
-        oc wait deployment -n $(params.target-namespace) $(tasks.sanitise-model-name.results.output-string)-$(params.model-version) --for condition=Available=True --timeout=120s
-        oc wait pod -n $(params.target-namespace) -l app=$(params.model-name)-$(params.model-version) --for condition=Ready=True --timeout=120s
+        oc wait deployment -n $(params.target-namespace) $(tasks.sanitise-model-name.results.output-string)-$(params.model-version) --for condition=Available=True --timeout=5m
+        oc wait pod -n $(params.target-namespace) -l app=$(params.model-name)-$(params.model-version) --for condition=Ready=True --timeout=5m
     taskRef:
       resolver: git
       params:

--- a/manifests/pipelines/s3-fetch-pipeline.yaml
+++ b/manifests/pipelines/s3-fetch-pipeline.yaml
@@ -250,8 +250,8 @@ spec:
                 resources: {}
         status: {}
         EOF
-        oc wait deployment -n $(params.target-namespace) $(tasks.sanitise-model-name.results.output-string)-$(params.model-version) --for condition=Available=True --timeout=120s
-        oc wait pod -n $(params.target-namespace) -l app=$(params.model-name)-$(params.model-version) --for condition=Ready=True --timeout=120s
+        oc wait deployment -n $(params.target-namespace) $(tasks.sanitise-model-name.results.output-string)-$(params.model-version) --for condition=Available=True --timeout=5m
+        oc wait pod -n $(params.target-namespace) -l app=$(params.model-name)-$(params.model-version) --for condition=Ready=True --timeout=5m
     taskRef:
       resolver: git
       params:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Waiting for the Deployment is sometimes timing out even though there is no error, so it is just slower.

## How Has This Been Tested?
Local cluster (where the current timeout was enough), PR check will also test it on OpenShift CI infrastructure.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
